### PR TITLE
Reload full model with optimizer state and epoch number

### DIFF
--- a/larq_zoo/utils.py
+++ b/larq_zoo/utils.py
@@ -72,4 +72,3 @@ def get_input_layer(input_shape, input_tensor):
     if not tf.keras.backend.is_keras_tensor(input_tensor):
         return tf.keras.layers.Input(tensor=input_tensor, shape=input_shape)
     return input_tensor
-


### PR DESCRIPTION
This is not the most elegant solution, but the new `ModelCheckpoint` callback in TF 2 and 1.14 isn't working correctly and we are currently running into OOM errors pretty often, so it is good to properly reload the models.