### PR TITLE
Revert model loading to fix multi GPU

### DIFF
--- a/larq_zoo/train.py
+++ b/larq_zoo/train.py
@@ -20,7 +20,9 @@ def train(build_model, dataset, hparams, output_dir, epochs, tensorboard):
         )
     if tensorboard:
         callbacks.append(
-            tf.keras.callbacks.TensorBoard(log_dir=output_dir, write_graph=False)
+            tf.keras.callbacks.TensorBoard(
+                log_dir=output_dir, write_graph=False, histogram_freq=10
+            )
         )
 
     with tf.device("/cpu:0"):

--- a/larq_zoo/utils.py
+++ b/larq_zoo/utils.py
@@ -22,7 +22,7 @@ class ModelCheckpoint(tf.keras.callbacks.ModelCheckpoint):
     def on_epoch_end(self, epoch, logs=None):
         super().on_epoch_end(epoch, logs=logs)
         with open(os.path.join(os.path.dirname(self.filepath), "stats.json"), "w") as f:
-            return json.dump({"epoch": epoch}, f)
+            return json.dump({"epoch": epoch + 1}, f)
 
 
 def get_distribution_scope(batch_size):


### PR DESCRIPTION
This will also reload the optimizer state in TF 2, but will only reload the weights with TF 1.