### PR TITLE
Pin larq and zookeeper versions

### DIFF
--- a/larq_zoo/train.py
+++ b/larq_zoo/train.py
@@ -5,7 +5,7 @@ import click
 
 @cli.command()
 @click.option("--tensorboard/--no-tensorboard", default=True)
-@build_train
+@build_train()
 def train(build_model, dataset, hparams, output_dir, epochs, tensorboard):
     import larq as lq
     from larq_zoo import utils

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/plumerai/larq-zoo",
     packages=find_packages(),
     license="Apache 2.0",
-    install_requires=["numpy~=1.15", "larq~=0.2.0", "zookeeper~=0.1.0"],
+    install_requires=["numpy~=1.15", "larq~=0.2.0", "zookeeper~=0.2.0"],
     extras_require={
         "tensorflow": ["tensorflow>=1.13.1"],
         "tensorflow_gpu": ["tensorflow-gpu>=1.13.1"],


### PR DESCRIPTION
This will only install patch updates automatically, so we need to also release a new version of `larq-zoo` if we ship a major/minor release of `larq`, but this will prevent us from accidentally pulling releases that might include breaking changes.