### PR TITLE
Fix code coverage path

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
         Python37_TF114:
           python.version: "3.7"
           tensorflow.version: "1.14.0"
-          pytest.args: "--cov=larq --cov-report=html --cov-config=.coveragerc"
+          pytest.args: "--cov=larq_zoo --cov-report=html --cov-config=.coveragerc"
         Python37_TF2:
           python.version: "3.7"
           tensorflow.version: "2.0.0-beta1"


### PR DESCRIPTION
I copy-pasted this from larq and forgot to change the module name. This should now report the correct code coverage.