### PR TITLE
Add links to view model architecture with netron

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,7 @@ BinaryAlexNet(include_top=True,
               classes=1000)
 ```
 
-Instantiates the Binary AlexNet architecture.
+Instantiates the Binary AlexNet architecture ([interactive architecture diagram](https://lutzroeder.github.io/netron/?url=https://cors-anywhere.herokuapp.com/https://github.com/larq/zoo/releases/download/binary_alexnet-v0.2.0/binary_alexnet.h5)).
 
 Optionally loads weights pre-trained on ImageNet.
 
@@ -54,7 +54,7 @@ BiRealNet(include_top=True,
           classes=1000)
 ```
 
-Instantiates the Bi-Real Net architecture.
+Instantiates the Bi-Real Net architecture ([interactive architecture diagram](https://lutzroeder.github.io/netron/?url=https://cors-anywhere.herokuapp.com/https://github.com/larq/zoo/releases/download/birealnet-v0.2.0/birealnet.h5)).
 
 Optionally loads weights pre-trained on ImageNet.
 
@@ -100,7 +100,7 @@ XNORNet(include_top=True,
         classes=1000)
 ```
 
-Instantiates the XNOR-Net architecture.
+Instantiates the XNOR-Net architecture ([interactive architecture diagram](https://lutzroeder.github.io/netron/?url=https://cors-anywhere.herokuapp.com/https://github.com/larq/zoo/releases/download/xnornet-v0.2.0/xnornet.h5)).
 
 Optionally loads weights pre-trained on ImageNet.
 


### PR DESCRIPTION
This will add links to the documentation which allows us to visualize the networks with netron in the browser. For this to work I needed to use a CORS proxy to workaround the default CORS policy set by GitHub pages. See https://github.com/lutzroeder/netron/issues/312

Note that for BinaryNet and XNOR-Net it might take quite long to open the website since it needs to first download the model file which also include all the weights.