### PR TITLE
Remove irrelevant documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -25,9 +25,8 @@ Optionally loads weights pre-trained on ImageNet.
   ImageNet), or the path to the weights file to be loaded.
 - `input_tensor`: optional Keras Tensor (i.e. output of `layers.Input()`) to use as
   image input for the model.
-- `input_shape`: optional shape tuple, only to be specified if `include_top` is False
-  (otherwise the input shape has to be `(224, 224, 3)` (with `channels_last` data
-  format) or `(3, 224, 224)` (with `channels_first` data format).
+- `input_shape`: optional shape tuple, only to be specified if `include_top` is False,
+  otherwise the input shape has to be `(224, 224, 3)`.
   It should have exactly 3 inputs channels.
 - `classes`: optional number of classes to classify images into, only to be specified
   if `include_top` is True, and if no `weights` argument is specified.
@@ -69,9 +68,8 @@ Optionally loads weights pre-trained on ImageNet.
   ImageNet), or the path to the weights file to be loaded.
 - `input_tensor`: optional Keras Tensor (i.e. output of `layers.Input()`) to use as
   image input for the model.
-- `input_shape`: optional shape tuple, only to be specified if `include_top` is False
-  (otherwise the input shape has to be `(224, 224, 3)` (with `channels_last` data
-  format) or `(3, 224, 224)` (with `channels_first` data format).
+- `input_shape`: optional shape tuple, only to be specified if `include_top` is False,
+  otherwise the input shape has to be `(224, 224, 3)`.
   It should have exactly 3 inputs channels.
 - `classes`: optional number of classes to classify images into, only to be specified
   if `include_top` is True, and if no `weights` argument is specified.
@@ -115,9 +113,8 @@ Optionally loads weights pre-trained on ImageNet.
   ImageNet), or the path to the weights file to be loaded.
 - `input_tensor`: optional Keras Tensor (i.e. output of `layers.Input()`) to use as
   image input for the model.
-- `input_shape`: optional shape tuple, only to be specified if `include_top` is False
-  (otherwise the input shape has to be `(224, 224, 3)` (with `channels_last` data
-  format) or `(3, 224, 224)` (with `channels_first` data format).
+- `input_shape`: optional shape tuple, only to be specified if `include_top` is False,
+  otherwise the input shape has to be `(224, 224, 3)`.
   It should have exactly 3 inputs channels.
 - `classes`: optional number of classes to classify images into, only to be specified
   if `include_top` is True, and if no `weights` argument is specified.

--- a/larq_zoo/binarynet.py
+++ b/larq_zoo/binarynet.py
@@ -102,9 +102,8 @@ def BinaryAlexNet(
         ImageNet), or the path to the weights file to be loaded.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
-    input_shape: optional shape tuple, only to be specified if `include_top` is False
-        (otherwise the input shape has to be `(224, 224, 3)` (with `channels_last` data
-        format) or `(3, 224, 224)` (with `channels_first` data format).
+    input_shape: optional shape tuple, only to be specified if `include_top` is False,
+        otherwise the input shape has to be `(224, 224, 3)`.
         It should have exactly 3 inputs channels.
     classes: optional number of classes to classify images into, only to be specified
         if `include_top` is True, and if no `weights` argument is specified.

--- a/larq_zoo/birealnet.py
+++ b/larq_zoo/birealnet.py
@@ -113,9 +113,8 @@ def BiRealNet(
         ImageNet), or the path to the weights file to be loaded.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
-    input_shape: optional shape tuple, only to be specified if `include_top` is False
-        (otherwise the input shape has to be `(224, 224, 3)` (with `channels_last` data
-        format) or `(3, 224, 224)` (with `channels_first` data format).
+    input_shape: optional shape tuple, only to be specified if `include_top` is False,
+        otherwise the input shape has to be `(224, 224, 3)`.
         It should have exactly 3 inputs channels.
     classes: optional number of classes to classify images into, only to be specified
         if `include_top` is True, and if no `weights` argument is specified.


### PR DESCRIPTION
`tf.keras` uses `channels_last`, so we can remove this note in the docs.