### PR TITLE
Correctly pass top argument to decode_predictions

### DIFF
--- a/larq_zoo/utils.py
+++ b/larq_zoo/utils.py
@@ -109,4 +109,4 @@ def decode_predictions(preds, top=5, **kwargs):
     # Raises
     ValueError: In case of invalid shape of the `pred` array (must be 2D).
     """
-    return keras_decode_predictions(preds, top=5, **kwargs)
+    return keras_decode_predictions(preds, top=top, **kwargs)


### PR DESCRIPTION
Previously the `top` argument in `larq_zoo. decode_predictions` wasn't respected and always returned the Top 5 predictions.