### PR TITLE
Add names to all models

### DIFF
--- a/larq_zoo/binarynet.py
+++ b/larq_zoo/binarynet.py
@@ -68,7 +68,7 @@ def binary_alexnet(
         out = dense_block(out, num_classes)
         out = tf.keras.layers.Activation("softmax")(out)
 
-    return tf.keras.Model(inputs=img_input, outputs=out)
+    return tf.keras.Model(inputs=img_input, outputs=out, name="binary_alexnet")
 
 
 @registry.register_hparams(binary_alexnet)

--- a/larq_zoo/birealnet.py
+++ b/larq_zoo/birealnet.py
@@ -70,7 +70,7 @@ def birealnet(args, input_shape, num_classes, input_tensor=None, include_top=Tru
         out = tf.keras.layers.GlobalAvgPool2D()(out)
         out = tf.keras.layers.Dense(num_classes, activation="softmax")(out)
 
-    return tf.keras.Model(inputs=img_input, outputs=out, name="birealnet")
+    return tf.keras.Model(inputs=img_input, outputs=out, name="birealnet18")
 
 
 @registry.register_hparams(birealnet)

--- a/larq_zoo/birealnet.py
+++ b/larq_zoo/birealnet.py
@@ -70,7 +70,7 @@ def birealnet(args, input_shape, num_classes, input_tensor=None, include_top=Tru
         out = tf.keras.layers.GlobalAvgPool2D()(out)
         out = tf.keras.layers.Dense(num_classes, activation="softmax")(out)
 
-    return tf.keras.Model(inputs=img_input, outputs=out)
+    return tf.keras.Model(inputs=img_input, outputs=out, name="birealnet")
 
 
 @registry.register_hparams(birealnet)

--- a/larq_zoo/densenet.py
+++ b/larq_zoo/densenet.py
@@ -72,11 +72,12 @@ def binary_densenet(
         x = keras.layers.Dense(
             num_classes, activation="softmax", kernel_initializer="he_normal"
         )(x)
-    return keras.Model(inputs=input, outputs=x)
+    return keras.Model(inputs=input, outputs=x, name=args.name)
 
 
 @registry.register_hparams(binary_densenet)
 class binary_densenet28(HParams):
+    name = "binary_densenet28"
     epochs = 120
     batch_size = 256
     learning_rate = 0.004
@@ -105,6 +106,7 @@ class binary_densenet28(HParams):
 
 @registry.register_hparams(binary_densenet)
 class binary_densenet37(binary_densenet28):
+    name = "binary_densenet37"
     batch_size = 192
     learning_steps = [100, 110]
     reduction = [3.3, 3.3, 4]
@@ -113,6 +115,7 @@ class binary_densenet37(binary_densenet28):
 
 @registry.register_hparams(binary_densenet)
 class binary_densenet37_dilated(binary_densenet37):
+    name = "binary_densenet37_dilated"
     epochs = 80
     batch_size = 256
     learning_steps = [60, 70]
@@ -121,6 +124,7 @@ class binary_densenet37_dilated(binary_densenet37):
 
 @registry.register_hparams(binary_densenet)
 class binary_densenet45(binary_densenet28):
+    name = "binary_densenet45"
     epochs = 125
     batch_size = 384
     learning_rate = 0.008

--- a/larq_zoo/dorefanet.py
+++ b/larq_zoo/dorefanet.py
@@ -60,7 +60,7 @@ def dorefa_net(hparams, input_shape, num_classes, input_tensor=None, include_top
         out = tf.keras.layers.Dense(num_classes, use_bias=True)(out)
         out = tf.keras.layers.Activation("softmax")(out)
 
-    return tf.keras.Model(inputs=img_input, outputs=out)
+    return tf.keras.Model(inputs=img_input, outputs=out, name="dorefanet")
 
 
 @lq.utils.register_keras_custom_object

--- a/larq_zoo/resnet_e.py
+++ b/larq_zoo/resnet_e.py
@@ -73,11 +73,12 @@ def resnet_e(args, input_shape, num_classes, input_tensor=None, include_top=True
         x = keras.layers.Dense(
             num_classes, activation="softmax", kernel_initializer="glorot_normal"
         )(x)
-    return keras.Model(inputs=input, outputs=x)
+    return keras.Model(inputs=input, outputs=x, name=args.name)
 
 
 @registry.register_hparams(resnet_e)
 class default(HParams):
+    name = "binary_resnet_e_18"
     epochs = 120
     batch_size = 1024
     num_layers = 18

--- a/larq_zoo/xnornet.py
+++ b/larq_zoo/xnornet.py
@@ -78,7 +78,7 @@ def xnornet(hparams, input_shape, num_classes, input_tensor=None, include_top=Tr
     else:
         inputs = img_input
 
-    return tf.keras.models.Model(inputs, x)
+    return tf.keras.models.Model(inputs, x, name="xnornet")
 
 
 @lq.utils.set_precision(1)


### PR DESCRIPTION
Keras applications names its models, which can be useful in certain contexts (e.g. when profiling a bunch of models at once). This PR adds the same functionality to `larq-zoo`.