### PR TITLE
Input shape docstring

### DIFF
--- a/larq_zoo/literature/binary_alex_net.py
+++ b/larq_zoo/literature/binary_alex_net.py
@@ -129,9 +129,8 @@ def BinaryAlexNet(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, only to be specified if `include_top` is False,
-        otherwise the input shape has to be `(224, 224, 3)`.
-        It should have exactly 3 inputs channels.
+    input_shape: optional shape tuple, otherwise the input shape has to be
+        `(224, 224, 3)`. It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/literature/binary_alex_net.py
+++ b/larq_zoo/literature/binary_alex_net.py
@@ -129,8 +129,9 @@ def BinaryAlexNet(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, otherwise the input shape has to be
-        `(224, 224, 3)`. It should have exactly 3 inputs channels.
+    input_shape: Optional shape tuple, to be specified if you would like to use a model
+        with an input image resolution that is not (224, 224, 3).
+        It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/literature/birealnet.py
+++ b/larq_zoo/literature/birealnet.py
@@ -134,9 +134,8 @@ def BiRealNet(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, only to be specified if `include_top` is False,
-        otherwise the input shape has to be `(224, 224, 3)`.
-        It should have exactly 3 inputs channels.
+    input_shape: optional shape tuple, otherwise the input shape has to be
+        `(224, 224, 3)`. It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/literature/birealnet.py
+++ b/larq_zoo/literature/birealnet.py
@@ -134,8 +134,9 @@ def BiRealNet(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, otherwise the input shape has to be
-        `(224, 224, 3)`. It should have exactly 3 inputs channels.
+    input_shape: Optional shape tuple, to be specified if you would like to use a model
+        with an input image resolution that is not (224, 224, 3).
+        It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/literature/densenet.py
+++ b/larq_zoo/literature/densenet.py
@@ -248,9 +248,8 @@ def BinaryDenseNet28(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, only to be specified if `include_top` is False,
-        otherwise the input shape has to be `(224, 224, 3)`.
-        It should have exactly 3 inputs channels.
+    input_shape: optional shape tuple, otherwise the input shape has to be
+        `(224, 224, 3)`. It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on
@@ -298,9 +297,8 @@ def BinaryDenseNet37(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, only to be specified if `include_top` is False,
-        otherwise the input shape has to be `(224, 224, 3)`.
-        It should have exactly 3 inputs channels.
+    input_shape: optional shape tuple, otherwise the input shape has to be
+        `(224, 224, 3)`. It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on
@@ -348,9 +346,8 @@ def BinaryDenseNet37Dilated(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, only to be specified if `include_top` is False,
-        otherwise the input shape has to be `(224, 224, 3)`.
-        It should have exactly 3 inputs channels.
+    input_shape: optional shape tuple, otherwise the input shape has to be
+        `(224, 224, 3)`. It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on
@@ -398,9 +395,8 @@ def BinaryDenseNet45(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, only to be specified if `include_top` is False,
-        otherwise the input shape has to be `(224, 224, 3)`.
-        It should have exactly 3 inputs channels.
+    input_shape: optional shape tuple, otherwise the input shape has to be
+        `(224, 224, 3)`. It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/literature/densenet.py
+++ b/larq_zoo/literature/densenet.py
@@ -248,8 +248,9 @@ def BinaryDenseNet28(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, otherwise the input shape has to be
-        `(224, 224, 3)`. It should have exactly 3 inputs channels.
+    input_shape: Optional shape tuple, to be specified if you would like to use a model
+        with an input image resolution that is not (224, 224, 3).
+        It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on
@@ -297,8 +298,9 @@ def BinaryDenseNet37(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, otherwise the input shape has to be
-        `(224, 224, 3)`. It should have exactly 3 inputs channels.
+    input_shape: Optional shape tuple, to be specified if you would like to use a model
+        with an input image resolution that is not (224, 224, 3).
+        It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on
@@ -346,8 +348,9 @@ def BinaryDenseNet37Dilated(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, otherwise the input shape has to be
-        `(224, 224, 3)`. It should have exactly 3 inputs channels.
+    input_shape: Optional shape tuple, to be specified if you would like to use a model
+        with an input image resolution that is not (224, 224, 3).
+        It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on
@@ -395,8 +398,9 @@ def BinaryDenseNet45(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, otherwise the input shape has to be
-        `(224, 224, 3)`. It should have exactly 3 inputs channels.
+    input_shape: Optional shape tuple, to be specified if you would like to use a model
+        with an input image resolution that is not (224, 224, 3).
+        It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/literature/dorefanet.py
+++ b/larq_zoo/literature/dorefanet.py
@@ -142,9 +142,8 @@ def DoReFaNet(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, only to be specified if `include_top` is False,
-        otherwise the input shape has to be `(224, 224, 3)`.
-        It should have exactly 3 inputs channels.
+    input_shape: optional shape tuple, otherwise the input shape has to be
+        `(224, 224, 3)`. It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/literature/dorefanet.py
+++ b/larq_zoo/literature/dorefanet.py
@@ -142,8 +142,9 @@ def DoReFaNet(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, otherwise the input shape has to be
-        `(224, 224, 3)`. It should have exactly 3 inputs channels.
+    input_shape: Optional shape tuple, to be specified if you would like to use a model
+        with an input image resolution that is not (224, 224, 3).
+        It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/literature/resnet_e.py
+++ b/larq_zoo/literature/resnet_e.py
@@ -157,9 +157,8 @@ def BinaryResNetE18(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, only to be specified if `include_top` is False,
-        otherwise the input shape has to be `(224, 224, 3)`.
-        It should have exactly 3 inputs channels.
+    input_shape: optional shape tuple, otherwise the input shape has to be
+        `(224, 224, 3)`. It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/literature/resnet_e.py
+++ b/larq_zoo/literature/resnet_e.py
@@ -157,8 +157,9 @@ def BinaryResNetE18(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, otherwise the input shape has to be
-        `(224, 224, 3)`. It should have exactly 3 inputs channels.
+    input_shape: Optional shape tuple, to be specified if you would like to use a model
+        with an input image resolution that is not (224, 224, 3).
+        It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/literature/xnornet.py
+++ b/larq_zoo/literature/xnornet.py
@@ -149,10 +149,8 @@ def XNORNet(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, only to be specified if `include_top` is False
-        (otherwise the input shape has to be `(224, 224, 3)` (with `channels_last` data
-        format) or `(3, 224, 224)` (with `channels_first` data format).
-        It should have exactly 3 inputs channels.
+    input_shape: optional shape tuple, otherwise the input shape has to be
+        `(224, 224, 3)`. It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/literature/xnornet.py
+++ b/larq_zoo/literature/xnornet.py
@@ -149,8 +149,9 @@ def XNORNet(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, otherwise the input shape has to be
-        `(224, 224, 3)`. It should have exactly 3 inputs channels.
+    input_shape: Optional shape tuple, to be specified if you would like to use a model
+        with an input image resolution that is not (224, 224, 3).
+        It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -145,8 +145,9 @@ def QuickNet(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, otherwise the input shape has to be
-        `(224, 224, 3)`. It should have exactly 3 inputs channels.
+    input_shape: Optional shape tuple, to be specified if you would like to use a model
+        with an input image resolution that is not (224, 224, 3).
+        It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -145,9 +145,8 @@ def QuickNet(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, only to be specified if `include_top` is False,
-        otherwise the input shape has to be `(224, 224, 3)`.
-        It should have exactly 3 inputs channels.
+    input_shape: optional shape tuple, otherwise the input shape has to be
+        `(224, 224, 3)`. It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/sota/quicknet_large.py
+++ b/larq_zoo/sota/quicknet_large.py
@@ -151,8 +151,9 @@ def QuickNetLarge(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, otherwise the input shape has to be
-        `(224, 224, 3)`. It should have exactly 3 inputs channels.
+    input_shape: Optional shape tuple, to be specified if you would like to use a model
+        with an input image resolution that is not (224, 224, 3).
+        It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on

--- a/larq_zoo/sota/quicknet_large.py
+++ b/larq_zoo/sota/quicknet_large.py
@@ -151,9 +151,8 @@ def QuickNetLarge(
     ```
 
     # Arguments
-    input_shape: optional shape tuple, only to be specified if `include_top` is False,
-        otherwise the input shape has to be `(224, 224, 3)`.
-        It should have exactly 3 inputs channels.
+    input_shape: optional shape tuple, otherwise the input shape has to be
+        `(224, 224, 3)`. It should have exactly 3 inputs channels.
     input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
         image input for the model.
     weights: one of `None` (random initialization), "imagenet" (pre-training on


### PR DESCRIPTION
We copied this from `tf.keras.applications`, but the `keras` behaviour has changed; you can now change the input shape if `include_top=True` but not if `weights="imagenet"` as well.

Instead of trying to cover all cases in the docstring, this PR just removes the outdated info (the user will have to rely on error messages, but these are quite descriptive).