### PR TITLE
Remove deprecated layer metrics kwarg

### DIFF
--- a/larq_zoo/literature/resnet_e.py
+++ b/larq_zoo/literature/resnet_e.py
@@ -60,7 +60,6 @@ class BinaryResNetE18Factory(ModelFactory):
             kernel_constraint=self.kernel_constraint,
             kernel_initializer="glorot_normal",
             use_bias=False,
-            metrics=[],
         )(x)
         x = tf.keras.layers.BatchNormalization(momentum=0.9, epsilon=1e-5)(x)
 

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -75,7 +75,6 @@ class QuickNetFactory(ModelFactory):
             kernel_initializer="glorot_normal",
             use_bias=False,
             activation="relu",
-            metrics=[],
         )(x)
         x = tf.keras.layers.BatchNormalization(momentum=0.9, epsilon=1e-5)(x)
         if downsample:

--- a/larq_zoo/sota/quicknet_large.py
+++ b/larq_zoo/sota/quicknet_large.py
@@ -84,7 +84,6 @@ class QuickNetLargeFactory(ModelFactory):
             kernel_initializer="glorot_normal",
             use_bias=False,
             activation="relu",
-            metrics=[],
         )(x)
 
         x = tf.keras.layers.BatchNormalization(momentum=0.9, epsilon=1e-5)(x)


### PR DESCRIPTION
This argument will be deprecated in the next release of larq (See https://github.com/larq/larq/pull/402)