### PR TITLE
Use AveragePooling2D instead of GlobalPooling2D

### DIFF
--- a/larq_zoo/core/test_utils.py
+++ b/larq_zoo/core/test_utils.py
@@ -1,0 +1,24 @@
+import tensorflow as tf
+
+from larq_zoo.core import utils
+
+
+def test_global_pool():
+    def build_model(input_res=(32, 32), data_format="channels_first"):
+        if data_format == "channels_first":
+            input_shape = (3, input_res[0], input_res[1])
+        else:
+            input_shape = (input_res[0], input_res[1], 3)
+        inp = tf.keras.Input(shape=input_shape)
+        x = tf.keras.layers.Conv2D(6, 3, 2, data_format=data_format)(inp)
+        x = utils.global_pool(x, data_format=data_format)
+        x = tf.keras.layers.Dense(2)(x)
+        return tf.keras.Model(inputs=inp, outputs=x)
+
+    for data_format in ["channels_first", "channels_last"]:
+        fixed_model = build_model()
+        dynamic_model = build_model(input_res=(None, 32))
+
+        for model in [fixed_model, dynamic_model]:
+            output_shape = model.outputs[0].get_shape().as_list()
+            assert output_shape == [None, 2]

--- a/larq_zoo/core/utils.py
+++ b/larq_zoo/core/utils.py
@@ -5,14 +5,13 @@ import sys
 from typing import Optional
 
 import tensorflow as tf
+from keras_applications.imagenet_utils import _obtain_input_shape
 from tensorflow import keras
 from tensorflow.keras.applications.vgg16 import (
     decode_predictions as keras_decode_predictions,
 )
 from tensorflow.python.eager.context import num_gpus
 from tensorflow.python.keras.backend import is_keras_tensor
-
-from keras_applications.imagenet_utils import _obtain_input_shape
 
 
 def slash_join(*args):

--- a/larq_zoo/core/utils.py
+++ b/larq_zoo/core/utils.py
@@ -103,6 +103,41 @@ def get_input_layer(input_shape, input_tensor):
     return input_tensor
 
 
+def global_pool(x: tf.Tensor, data_format: str = "channels_last") -> tf.Tensor:
+    """Global average 2D pooling and flattening.
+
+    Alternative to existing keras implementation of GlobalPooling2D.
+    AveragePooling2D is much faster than GlobalPooling2D on Larq Compute Engine.
+
+    # Arguments
+    x: 4D TensorFlow tensor.
+    data_format: data_format: A string, one of channels_last (default) or
+        channels_first. The ordering of the dimensions in the inputs. channels_last
+        corresponds to inputs with shape (batch, height, width, channels) while
+        channels_first corresponds to inputs with shape (batch, channels, height,
+        width). It defaults to "channels_last".
+
+    # Returns
+    2D TensorFlow tensor.
+
+    # Raises
+    ValueError: if tensor is not 4D or data_format is not recognized.
+    """
+    if len(x.get_shape()) != 4:
+        raise ValueError("Tensor is not 4D.")
+    if data_format not in ["channels_last", "channels_first"]:
+        raise ValueError("data_format not recognized.")
+
+    input_shape = x.get_shape().as_list()
+    pool_size = input_shape[1:3] if data_format == "channels_last" else input_shape[2:4]
+
+    x = tf.keras.layers.AveragePooling2D(pool_size=pool_size, data_format=data_format)(
+        x
+    )
+
+    return tf.keras.layers.Flatten()(x)
+
+
 def decode_predictions(preds, top=5, **kwargs):
     """Decodes the prediction of an ImageNet model.
 

--- a/larq_zoo/core/utils.py
+++ b/larq_zoo/core/utils.py
@@ -108,14 +108,14 @@ def global_pool(
 ) -> tf.Tensor:
     """Global average 2D pooling and flattening.
 
-    Alternative to existing keras implementation of GlobalAveragePooling2D.
+    Alternative to existing Keras implementation of GlobalAveragePooling2D.
     AveragePooling2D is much faster than GlobalAveragePooling2D on Larq Compute Engine.
     If the width or height of the input is dynamic, the function falls back to
     GlobalAveragePooling2D.
 
     # Arguments
     x: 4D TensorFlow tensor.
-    data_format: data_format: A string, one of channels_last (default) or
+    data_format: A string, one of channels_last (default) or
         channels_first. The ordering of the dimensions in the inputs. channels_last
         corresponds to inputs with shape (batch, height, width, channels) while
         channels_first corresponds to inputs with shape (batch, channels, height,

--- a/larq_zoo/core/utils.py
+++ b/larq_zoo/core/utils.py
@@ -134,7 +134,7 @@ def global_pool(
     input_shape = x.get_shape().as_list()
     pool_size = input_shape[1:3] if data_format == "channels_last" else input_shape[2:4]
 
-    if not (pool_size[0] is None) or (pool_size[1] is None):
+    if not (pool_size[0] is None or pool_size[1] is None):
 
         def fun(x_):
             x_ = tf.keras.layers.AveragePooling2D(

--- a/larq_zoo/literature/birealnet.py
+++ b/larq_zoo/literature/birealnet.py
@@ -86,7 +86,7 @@ class BiRealNetFactory(ModelFactory):
 
         # Layer 18
         if self.include_top:
-            out = tf.keras.layers.GlobalAvgPool2D()(out)
+            out = utils.global_pool(out)
             out = tf.keras.layers.Dense(self.num_classes, activation="softmax")(out)
 
         model = tf.keras.Model(inputs=self.image_input, outputs=out, name="birealnet18")

--- a/larq_zoo/literature/densenet.py
+++ b/larq_zoo/literature/densenet.py
@@ -95,7 +95,7 @@ class BinaryDenseNetFactory(ModelFactory):
         x = tf.keras.layers.Activation("relu")(x)
 
         if self.include_top:
-            x = tf.keras.layers.GlobalAvgPool2D()(x)
+            x = utils.global_pool(x)
             x = tf.keras.layers.Dense(
                 self.num_classes, activation="softmax", kernel_initializer="he_normal"
             )(x)

--- a/larq_zoo/literature/resnet_e.py
+++ b/larq_zoo/literature/resnet_e.py
@@ -100,7 +100,7 @@ class BinaryResNetE18Factory(ModelFactory):
         x = tf.keras.layers.Activation("relu")(x)
 
         if self.include_top:
-            x = tf.keras.layers.GlobalAvgPool2D()(x)
+            x = utils.global_pool(x)
             x = tf.keras.layers.Dense(
                 self.num_classes,
                 activation="softmax",

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -95,7 +95,7 @@ class QuickNetFactory(ModelFactory):
         x = tf.keras.layers.Activation("relu")(x)
 
         if self.include_top:
-            x = tf.keras.layers.GlobalAvgPool2D()(x)
+            x = utils.global_pool(x)
             x = tf.keras.layers.Dense(
                 self.num_classes,
                 activation="softmax",

--- a/larq_zoo/sota/quicknet_large.py
+++ b/larq_zoo/sota/quicknet_large.py
@@ -13,8 +13,7 @@ def squeeze_and_excite(inp: tf.Tensor, strides: int = 1, r: int = 16):
     """Squeeze and Excite as per [Squeeze-and-Excitation Networks](https://arxiv.org/abs/1709.01507)"""
     C = inp.get_shape().as_list()[-1]
 
-    out = tf.keras.layers.GlobalAvgPool2D()(inp)
-    out = tf.keras.layers.Flatten()(out)
+    out = utils.global_pool(inp)
     out = tf.keras.layers.Dense(
         C // r,
         activation="relu",
@@ -101,7 +100,7 @@ class QuickNetLargeFactory(ModelFactory):
 
         x = tf.keras.layers.Activation("relu")(x)
         if self.include_top:
-            x = tf.keras.layers.GlobalAvgPool2D()(x)
+            x = utils.global_pool(x)
             x = tf.keras.layers.Dense(
                 self.num_classes,
                 activation="softmax",


### PR DESCRIPTION
AveragePooling2D has been found to be significantly faster than GlobalPooling2D when running models on LCE/TFLite.

This PR replaces global pooling for all models, not just QuickNet, to make it easier for users to build fast, LCE-compatible models.

(Note that ideally, this would be handled by TFLite or the LCE converter instead; this is basically a temporary fix.)

closes #126 

