### PR TITLE
Make min_size in validate_input an argument for Cifar training

### DIFF
--- a/larq_zoo/core/model_factory.py
+++ b/larq_zoo/core/model_factory.py
@@ -41,7 +41,7 @@ class ModelFactory:
 
     input_shape: Optional[Tuple[DimType, DimType, DimType]] = Field(None)
     input_tensor: Optional[tf.Tensor] = Field(None)
-    min_size: Optional[int] = Field(64)
+    min_input_resolution: Optional[int] = Field(64)
 
     @property
     def image_input(self) -> tf.Tensor:
@@ -51,7 +51,7 @@ class ModelFactory:
                 self.weights,
                 self.include_top,
                 self.num_classes,
-                self.min_size,
+                self.min_input_resolution,
             )
             self._image_input = utils.get_input_layer(input_shape, self.input_tensor)
         return self._image_input

--- a/larq_zoo/core/model_factory.py
+++ b/larq_zoo/core/model_factory.py
@@ -41,17 +41,12 @@ class ModelFactory:
 
     input_shape: Optional[Tuple[DimType, DimType, DimType]] = Field(None)
     input_tensor: Optional[tf.Tensor] = Field(None)
-    min_input_resolution: Optional[int] = Field(64)
 
     @property
     def image_input(self) -> tf.Tensor:
         if not hasattr(self, "_image_input"):
             input_shape = utils.validate_input(
-                self.input_shape,
-                self.weights,
-                self.include_top,
-                self.num_classes,
-                self.min_input_resolution,
+                self.input_shape, self.weights, self.include_top, self.num_classes,
             )
             self._image_input = utils.get_input_layer(input_shape, self.input_tensor)
         return self._image_input

--- a/larq_zoo/core/model_factory.py
+++ b/larq_zoo/core/model_factory.py
@@ -41,12 +41,17 @@ class ModelFactory:
 
     input_shape: Optional[Tuple[DimType, DimType, DimType]] = Field(None)
     input_tensor: Optional[tf.Tensor] = Field(None)
+    min_size: Optional[int] = Field(64)
 
     @property
     def image_input(self) -> tf.Tensor:
         if not hasattr(self, "_image_input"):
             input_shape = utils.validate_input(
-                self.input_shape, self.weights, self.include_top, self.num_classes
+                self.input_shape,
+                self.weights,
+                self.include_top,
+                self.num_classes,
+                self.min_size,
             )
             self._image_input = utils.get_input_layer(input_shape, self.input_tensor)
         return self._image_input

--- a/larq_zoo/core/utils.py
+++ b/larq_zoo/core/utils.py
@@ -70,7 +70,7 @@ def get_distribution_scope(batch_size):
     return distribution_scope()
 
 
-def validate_input(input_shape, weights, include_top, classes, min_size):
+def validate_input(input_shape, weights, include_top, classes, min_input_resolution):
     if not (weights in {"imagenet", None} or os.path.exists(weights)):
         raise ValueError(
             "The `weights` argument should be either `None` (random initialization), "
@@ -88,7 +88,7 @@ def validate_input(input_shape, weights, include_top, classes, min_size):
     return _obtain_input_shape(
         input_shape,
         default_size=224,
-        min_size=min_size,
+        min_size=min_input_resolution,
         data_format=keras.backend.image_data_format(),
         require_flatten=include_top,
         weights=weights,

--- a/larq_zoo/core/utils.py
+++ b/larq_zoo/core/utils.py
@@ -70,7 +70,7 @@ def get_distribution_scope(batch_size):
     return distribution_scope()
 
 
-def validate_input(input_shape, weights, include_top, classes, min_input_resolution):
+def validate_input(input_shape, weights, include_top, classes):
     if not (weights in {"imagenet", None} or os.path.exists(weights)):
         raise ValueError(
             "The `weights` argument should be either `None` (random initialization), "
@@ -88,7 +88,7 @@ def validate_input(input_shape, weights, include_top, classes, min_input_resolut
     return _obtain_input_shape(
         input_shape,
         default_size=224,
-        min_size=min_input_resolution,
+        min_size=0,
         data_format=keras.backend.image_data_format(),
         require_flatten=include_top,
         weights=weights,

--- a/larq_zoo/core/utils.py
+++ b/larq_zoo/core/utils.py
@@ -70,7 +70,7 @@ def get_distribution_scope(batch_size):
     return distribution_scope()
 
 
-def validate_input(input_shape, weights, include_top, classes):
+def validate_input(input_shape, weights, include_top, classes, min_size):
     if not (weights in {"imagenet", None} or os.path.exists(weights)):
         raise ValueError(
             "The `weights` argument should be either `None` (random initialization), "
@@ -88,7 +88,7 @@ def validate_input(input_shape, weights, include_top, classes):
     return _obtain_input_shape(
         input_shape,
         default_size=224,
-        min_size=64,
+        min_size=min_size,
         data_format=keras.backend.image_data_format(),
         require_flatten=include_top,
         weights=weights,

--- a/larq_zoo/literature/resnet_e.py
+++ b/larq_zoo/literature/resnet_e.py
@@ -19,8 +19,6 @@ class BinaryResNetE18Factory(ModelFactory):
     kernel_quantizer = Field(lambda: lq.quantizers.SteSign(clip_value=1.25))
     kernel_constraint = Field(lambda: lq.constraints.WeightClip(clip_value=1.25))
 
-    min_input_resolution: int = Field(32)
-
     @property
     def spec(self):
         spec = {

--- a/larq_zoo/literature/resnet_e.py
+++ b/larq_zoo/literature/resnet_e.py
@@ -19,6 +19,8 @@ class BinaryResNetE18Factory(ModelFactory):
     kernel_quantizer = Field(lambda: lq.quantizers.SteSign(clip_value=1.25))
     kernel_constraint = Field(lambda: lq.constraints.WeightClip(clip_value=1.25))
 
+    min_input_resolution: int = Field(32)
+
     @property
     def spec(self):
         spec = {


### PR DESCRIPTION
The ResnetE18 model code allows it to train on small datasets such as Cifar10. Because the min_size is hardcoded the check for a valid input shape throws an error regardless. I suggest making min_size an argument such that when training on small datasets we can change the min_size. 
```   
model = ComponentField(BinaryResNetE18Factory, weights=None,, input_shape=(32, 32, 3), min_size=32)
``` 