### PR TITLE
Explicitly compute softmax in float32

### DIFF
--- a/larq_zoo/literature/binary_alex_net.py
+++ b/larq_zoo/literature/binary_alex_net.py
@@ -79,7 +79,7 @@ class BinaryAlexNetFactory(ModelFactory):
             out = self.dense_block(out, units=4096)
             out = self.dense_block(out, units=4096)
             out = self.dense_block(out, self.num_classes)
-            out = tf.keras.layers.Activation("softmax")(out)
+            out = tf.keras.layers.Activation("softmax", dtype="float32")(out)
 
         model = tf.keras.models.Model(
             inputs=self.image_input, outputs=out, name="binary_alexnet"

--- a/larq_zoo/literature/birealnet.py
+++ b/larq_zoo/literature/birealnet.py
@@ -87,7 +87,8 @@ class BiRealNetFactory(ModelFactory):
         # Layer 18
         if self.include_top:
             out = utils.global_pool(out)
-            out = tf.keras.layers.Dense(self.num_classes, activation="softmax")(out)
+            out = tf.keras.layers.Dense(self.num_classes)(out)
+            out = tf.keras.layers.Activation("softmax", dtype="float32")(out)
 
         model = tf.keras.Model(inputs=self.image_input, outputs=out, name="birealnet18")
 

--- a/larq_zoo/literature/densenet.py
+++ b/larq_zoo/literature/densenet.py
@@ -96,9 +96,10 @@ class BinaryDenseNetFactory(ModelFactory):
 
         if self.include_top:
             x = utils.global_pool(x)
-            x = tf.keras.layers.Dense(
-                self.num_classes, activation="softmax", kernel_initializer="he_normal"
-            )(x)
+            x = tf.keras.layers.Dense(self.num_classes, kernel_initializer="he_normal")(
+                x
+            )
+            x = tf.keras.layers.Activation("softmax", dtype="float32")(x)
 
         model = BinaryDenseNet(inputs=self.image_input, outputs=x, name=self.name)
 

--- a/larq_zoo/literature/dorefanet.py
+++ b/larq_zoo/literature/dorefanet.py
@@ -95,7 +95,7 @@ class DoReFaNetFactory(ModelFactory):
             out = self.fully_connected_block(out, units=4096)
             out = tf.keras.layers.Activation("clip_by_value_activation")(out)
             out = tf.keras.layers.Dense(self.num_classes, use_bias=True)(out)
-            out = tf.keras.layers.Activation("softmax")(out)
+            out = tf.keras.layers.Activation("softmax", dtype="float32")(out)
 
         model = tf.keras.Model(inputs=self.image_input, outputs=out, name="dorefanet")
 

--- a/larq_zoo/literature/resnet_e.py
+++ b/larq_zoo/literature/resnet_e.py
@@ -102,10 +102,9 @@ class BinaryResNetE18Factory(ModelFactory):
         if self.include_top:
             x = utils.global_pool(x)
             x = tf.keras.layers.Dense(
-                self.num_classes,
-                activation="softmax",
-                kernel_initializer="glorot_normal",
+                self.num_classes, kernel_initializer="glorot_normal"
             )(x)
+            x = tf.keras.layers.Activation("softmax", dtype="float32")(x)
 
         model = tf.keras.Model(
             inputs=self.image_input,

--- a/larq_zoo/literature/xnornet.py
+++ b/larq_zoo/literature/xnornet.py
@@ -100,7 +100,7 @@ class XNORNetFactory(ModelFactory):
                 use_bias=False,
                 kernel_regularizer=self.kernel_regularizer,
             )(x)
-            x = tf.keras.layers.Activation("softmax")(x)
+            x = tf.keras.layers.Activation("softmax", dtype="float32")(x)
 
         model = tf.keras.models.Model(
             inputs=self.image_input, outputs=x, name="xnornet"

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -97,10 +97,9 @@ class QuickNetFactory(ModelFactory):
         if self.include_top:
             x = utils.global_pool(x)
             x = tf.keras.layers.Dense(
-                self.num_classes,
-                activation="softmax",
-                kernel_initializer="glorot_normal",
+                self.num_classes, kernel_initializer="glorot_normal",
             )(x)
+            x = tf.keras.layers.Activation("softmax", dtype="float32")(x)
 
         model = tf.keras.Model(inputs=self.image_input, outputs=x, name="quicknet")
 

--- a/larq_zoo/sota/quicknet_large.py
+++ b/larq_zoo/sota/quicknet_large.py
@@ -102,10 +102,9 @@ class QuickNetLargeFactory(ModelFactory):
         if self.include_top:
             x = utils.global_pool(x)
             x = tf.keras.layers.Dense(
-                self.num_classes,
-                activation="softmax",
-                kernel_initializer="glorot_normal",
+                self.num_classes, kernel_initializer="glorot_normal",
             )(x)
+            x = tf.keras.layers.Activation("softmax", dtype="float32")(x)
 
         model = tf.keras.Model(
             inputs=self.image_input, outputs=x, name="quicknet_large"


### PR DESCRIPTION
The [Keras mixed precision guide](https://www.tensorflow.org/guide/keras/mixed_precision) recommends computing the sofmax in float32 for better numerical stability. If I recall correctly this was done implicitely in TensorFlow 2.0 since the softmax op was [blacklisted in the mixed precision graph rewrite](https://github.com/tensorflow/tensorflow/blob/v2.0.0/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h#L146-L174). As of TensorFlow 2.1.0 this is no longer the case so we should follow the recommendation of the guide and explicitly set the data type.