### PR TITLE
Implement one-padding and reduce number of SE blocks for QuickNet

### DIFF
--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -140,7 +140,7 @@ def QuickNet(
     Optionally loads weights pre-trained on ImageNet.
 
     ```netron
-    quicknet-v0.1.0/quicknet.json
+    quicknet-v0.2.0/quicknet.json
     ```
 
     # Arguments

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -69,6 +69,7 @@ class QuickNetFactory(ModelFactory):
             kernel_size=3,
             strides=strides,
             padding="Same",
+            pad_values=1.0,
             input_quantizer=self.input_quantizer,
             kernel_quantizer=self.kernel_quantizer,
             kernel_constraint=self.kernel_constraint,
@@ -97,7 +98,7 @@ class QuickNetFactory(ModelFactory):
         if self.include_top:
             x = utils.global_pool(x)
             x = tf.keras.layers.Dense(
-                self.num_classes, kernel_initializer="glorot_normal",
+                self.num_classes, kernel_initializer="glorot_normal"
             )(x)
             x = tf.keras.layers.Activation("softmax", dtype="float32")(x)
 
@@ -109,16 +110,16 @@ class QuickNetFactory(ModelFactory):
             if self.include_top:
                 weights_path = utils.download_pretrained_model(
                     model="quicknet",
-                    version="v0.1.0",
+                    version="v0.2.0",
                     file="quicknet_weights.h5",
-                    file_hash="f52abb0ce984015889f8a8842944eed1bfad06897d745c7b58eb663b3457cd3c",
+                    file_hash="6a765f120ba7b62a7740e842c4f462eb7ba3dd65eb46b4694c5bc8169618fae7",
                 )
             else:
                 weights_path = utils.download_pretrained_model(
                     model="quicknet",
-                    version="v0.1.0",
+                    version="v0.2.0",
                     file="quicknet_weights_notop.h5",
-                    file_hash="057391ea350ce0af33194db300d3d9d690c8fb5b11427bbaf37504af257e9dc5",
+                    file_hash="5bf2fc450fb8cc322b33a16410bf88fed09d05c221550c2d5805a04985383ac2",
                 )
             model.load_weights(weights_path)
         elif self.weights is not None:

--- a/larq_zoo/sota/quicknet_large.py
+++ b/larq_zoo/sota/quicknet_large.py
@@ -71,8 +71,8 @@ class QuickNetLargeFactory(ModelFactory):
         else:
             residual = x
 
-        use_se = filters not in [64, 128]
-        if use_se:
+        use_squeeze_and_excite = filters not in (64, 128)
+        if use_squeeze_and_excite:
             y = squeeze_and_excite(x, strides=strides)
         x = lq.layers.QuantConv2D(
             filters,
@@ -90,8 +90,8 @@ class QuickNetLargeFactory(ModelFactory):
 
         x = tf.keras.layers.BatchNormalization(momentum=0.9, epsilon=1e-5)(x)
 
-        if use_se:
-            x = tf.multiply(x, y)
+        if use_squeeze_and_excite:
+            x *= y
 
         return tf.keras.layers.add([x, residual])
 

--- a/larq_zoo/sota/quicknet_large.py
+++ b/larq_zoo/sota/quicknet_large.py
@@ -151,7 +151,7 @@ def QuickNetLarge(
     Optionally loads weights pre-trained on ImageNet.
 
     ```netron
-    quicknet_large-v0.1.0/quicknet_large.json
+    quicknet_large-v0.2.0/quicknet_large.json
     ```
 
     # Arguments

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/plumerai/larq-zoo",
     packages=find_packages(),
     license="Apache 2.0",
-    install_requires=["numpy~=1.15", "larq>=0.8.4,<0.10.0", "zookeeper~=1.0.b5"],
+    install_requires=["numpy~=1.15", "larq>=0.9.2,<0.10.0", "zookeeper~=1.0.b5"],
     extras_require={
         "tensorflow": ["tensorflow>=1.14.0"],
         "tensorflow_gpu": ["tensorflow-gpu>=1.14.0"],


### PR DESCRIPTION
This PR introduces one-padding for QuickNet and QuickNet large, and reduces the number of squeeze & excite blocks on QuickNet Large. This leads to faster inference times at no cost in accuracy.

The new benchmark results are described in https://github.com/larq/compute-engine/pull/294.

The new model files are released in:
- https://github.com/larq/zoo/releases/tag/quicknet-v0.2.0
- https://github.com/larq/zoo/releases/tag/quicknet_large-v0.2.0