### PR TITLE
Add model metrics to docstrings

### DIFF
--- a/larq_zoo/literature/binary_alex_net.py
+++ b/larq_zoo/literature/binary_alex_net.py
@@ -128,6 +128,12 @@ def BinaryAlexNet(
     /plots/binary_alexnet.vg.json
     ```
 
+    # ImageNet Metrics
+    Top-1 Accuracy: 36.30 %
+    Top-5 Accuracy: 61.53 %
+    Parameters: 61 859 192
+    Memory: 7.49 MB
+
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
         with an input image resolution that is not (224, 224, 3).

--- a/larq_zoo/literature/binary_alex_net.py
+++ b/larq_zoo/literature/binary_alex_net.py
@@ -129,10 +129,9 @@ def BinaryAlexNet(
     ```
 
     # ImageNet Metrics
-    Top-1 Accuracy: 36.30 %
-    Top-5 Accuracy: 61.53 %
-    Parameters: 61 859 192
-    Memory: 7.49 MB
+    | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
+    | -------------- | -------------- | ---------- | ------- |
+    | 36.30 %        | 61.53 %        | 61 859 192 | 7.49 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model

--- a/larq_zoo/literature/binary_alex_net.py
+++ b/larq_zoo/literature/binary_alex_net.py
@@ -129,6 +129,7 @@ def BinaryAlexNet(
     ```
 
     # ImageNet Metrics
+
     | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
     | -------------- | -------------- | ---------- | ------- |
     | 36.30 %        | 61.53 %        | 61 859 192 | 7.49 MB |

--- a/larq_zoo/literature/birealnet.py
+++ b/larq_zoo/literature/birealnet.py
@@ -134,6 +134,12 @@ def BiRealNet(
     /plots/birealnet.vg.json
     ```
 
+    # ImageNet Metrics
+    Top-1 Accuracy: 57.47 %
+    Top-5 Accuracy: 79.84 %
+    Parameters: 11 699 112
+    Memory: 4.03 MB
+
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
         with an input image resolution that is not (224, 224, 3).

--- a/larq_zoo/literature/birealnet.py
+++ b/larq_zoo/literature/birealnet.py
@@ -135,6 +135,7 @@ def BiRealNet(
     ```
 
     # ImageNet Metrics
+
     | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
     | -------------- | -------------- | ---------- | ------- |
     | 57.47 %        | 79.84 %        | 11 699 112 | 4.03 MB |

--- a/larq_zoo/literature/birealnet.py
+++ b/larq_zoo/literature/birealnet.py
@@ -135,10 +135,9 @@ def BiRealNet(
     ```
 
     # ImageNet Metrics
-    Top-1 Accuracy: 57.47 %
-    Top-5 Accuracy: 79.84 %
-    Parameters: 11 699 112
-    Memory: 4.03 MB
+    | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
+    | -------------- | -------------- | ---------- | ------- |
+    | 57.47 %        | 79.84 %        | 11 699 112 | 4.03 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model

--- a/larq_zoo/literature/densenet.py
+++ b/larq_zoo/literature/densenet.py
@@ -249,9 +249,10 @@ def BinaryDenseNet28(
     ```
 
     # ImageNet Metrics
+
     | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
     | -------------- | -------------- | ---------- | ------- |
-    | 60.91 %        | 82.83 %        | 5 150 504 | 4.12 MB |
+    | 60.91 %        | 82.83 %        | 5 150 504  | 4.12 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
@@ -304,9 +305,10 @@ def BinaryDenseNet37(
     ```
 
     # ImageNet Metrics
+
     | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
     | -------------- | -------------- | ---------- | ------- |
-    | 62.89 %        | 84.19 %        | 8 734 120 | 5.25 MB |
+    | 62.89 %        | 84.19 %        | 8 734 120  | 5.25 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
@@ -359,9 +361,10 @@ def BinaryDenseNet37Dilated(
     ```
 
     # ImageNet Metrics
+
     | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
     | -------------- | -------------- | ---------- | ------- |
-    | 64.34 %        | 85.15 %        | 8 734 120 | 5.25 MB |
+    | 64.34 %        | 85.15 %        | 8 734 120  | 5.25 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
@@ -414,6 +417,7 @@ def BinaryDenseNet45(
     ```
 
     # ImageNet Metrics
+
     | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
     | -------------- | -------------- | ---------- | ------- |
     | 64.59 %        | 85.21 %        | 13 939 240 | 7.54 MB |

--- a/larq_zoo/literature/densenet.py
+++ b/larq_zoo/literature/densenet.py
@@ -249,10 +249,9 @@ def BinaryDenseNet28(
     ```
 
     # ImageNet Metrics
-    Top-1 Accuracy: 60.91 %
-    Top-5 Accuracy: 82.83 %
-    Parameters: 5 150 504
-    Memory: 4.12 MB
+    | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
+    | -------------- | -------------- | ---------- | ------- |
+    | 60.91 %        | 82.83 %        | 5 150 504 | 4.12 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
@@ -305,10 +304,9 @@ def BinaryDenseNet37(
     ```
 
     # ImageNet Metrics
-    Top-1 Accuracy: 62.89 %
-    Top-5 Accuracy: 84.19 %
-    Parameters: 8 734 120
-    Memory: 5.25 MB
+    | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
+    | -------------- | -------------- | ---------- | ------- |
+    | 62.89 %        | 84.19 %        | 8 734 120 | 5.25 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
@@ -361,10 +359,9 @@ def BinaryDenseNet37Dilated(
     ```
 
     # ImageNet Metrics
-    Top-1 Accuracy: 64.34 %
-    Top-5 Accuracy: 85.15 %
-    Parameters: 8 734 120
-    Memory: 5.25 MB
+    | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
+    | -------------- | -------------- | ---------- | ------- |
+    | 64.34 %        | 85.15 %        | 8 734 120 | 5.25 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
@@ -417,10 +414,9 @@ def BinaryDenseNet45(
     ```
 
     # ImageNet Metrics
-    Top-1 Accuracy: 64.59 %
-    Top-5 Accuracy: 85.21 %
-    Parameters: 13 939 240
-    Memory: 7.54 MB
+    | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
+    | -------------- | -------------- | ---------- | ------- |
+    | 64.59 %        | 85.21 %        | 13 939 240 | 7.54 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model

--- a/larq_zoo/literature/densenet.py
+++ b/larq_zoo/literature/densenet.py
@@ -248,6 +248,12 @@ def BinaryDenseNet28(
     /plots/densenet_28.vg.json
     ```
 
+    # ImageNet Metrics
+    Top-1 Accuracy: 60.91 %
+    Top-5 Accuracy: 82.83 %
+    Parameters: 5 150 504
+    Memory: 4.12 MB
+
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
         with an input image resolution that is not (224, 224, 3).
@@ -297,6 +303,12 @@ def BinaryDenseNet37(
     ```plot-altair
     /plots/densenet_37.vg.json
     ```
+
+    # ImageNet Metrics
+    Top-1 Accuracy: 62.89 %
+    Top-5 Accuracy: 84.19 %
+    Parameters: 8 734 120
+    Memory: 5.25 MB
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
@@ -348,6 +360,12 @@ def BinaryDenseNet37Dilated(
     /plots/densenet_37_dilated.vg.json
     ```
 
+    # ImageNet Metrics
+    Top-1 Accuracy: 64.34 %
+    Top-5 Accuracy: 85.15 %
+    Parameters: 8 734 120
+    Memory: 5.25 MB
+
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
         with an input image resolution that is not (224, 224, 3).
@@ -397,6 +415,12 @@ def BinaryDenseNet45(
     ```plot-altair
     /plots/densenet_45.vg.json
     ```
+
+    # ImageNet Metrics
+    Top-1 Accuracy: 64.59 %
+    Top-5 Accuracy: 85.21 %
+    Parameters: 13 939 240
+    Memory: 7.54 MB
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model

--- a/larq_zoo/literature/dorefanet.py
+++ b/larq_zoo/literature/dorefanet.py
@@ -146,6 +146,10 @@ def DoReFaNet(
     Top-5 Accuracy: 76.50 %
     Parameters: 62 403 912
     Memory: 22.84 MB
+    # ImageNet Metrics
+    | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
+    | -------------- | -------------- | ---------- | ------- |
+    | 53.39 %        | 76.50 %        | 62 403 912 | 22.84 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model

--- a/larq_zoo/literature/dorefanet.py
+++ b/larq_zoo/literature/dorefanet.py
@@ -142,11 +142,7 @@ def DoReFaNet(
     ```
 
     # ImageNet Metrics
-    Top-1 Accuracy: 53.39 %
-    Top-5 Accuracy: 76.50 %
-    Parameters: 62 403 912
-    Memory: 22.84 MB
-    # ImageNet Metrics
+
     | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
     | -------------- | -------------- | ---------- | ------- |
     | 53.39 %        | 76.50 %        | 62 403 912 | 22.84 MB |

--- a/larq_zoo/literature/dorefanet.py
+++ b/larq_zoo/literature/dorefanet.py
@@ -141,6 +141,12 @@ def DoReFaNet(
     /plots/dorefanet.vg.json
     ```
 
+    # ImageNet Metrics
+    Top-1 Accuracy: 53.39 %
+    Top-5 Accuracy: 76.50 %
+    Parameters: 62 403 912
+    Memory: 22.84 MB
+
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
         with an input image resolution that is not (224, 224, 3).

--- a/larq_zoo/literature/resnet_e.py
+++ b/larq_zoo/literature/resnet_e.py
@@ -155,10 +155,9 @@ def BinaryResNetE18(
     ```
 
     # ImageNet Metrics
-    Top-1 Accuracy: 58.32 %
-    Top-5 Accuracy: 80.79 %
-    Parameters: 11 699 368
-    Memory: 4.03 MB
+    | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
+    | -------------- | -------------- | ---------- | ------- |
+    | 58.32 %        | 80.79 %        | 11 699 368 | 4.03 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model

--- a/larq_zoo/literature/resnet_e.py
+++ b/larq_zoo/literature/resnet_e.py
@@ -155,6 +155,7 @@ def BinaryResNetE18(
     ```
 
     # ImageNet Metrics
+
     | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
     | -------------- | -------------- | ---------- | ------- |
     | 58.32 %        | 80.79 %        | 11 699 368 | 4.03 MB |

--- a/larq_zoo/literature/resnet_e.py
+++ b/larq_zoo/literature/resnet_e.py
@@ -154,6 +154,12 @@ def BinaryResNetE18(
     /plots/resnet_e_18.vg.json
     ```
 
+    # ImageNet Metrics
+    Top-1 Accuracy: 58.32 %
+    Top-5 Accuracy: 80.79 %
+    Parameters: 11 699 368
+    Memory: 4.03 MB
+
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
         with an input image resolution that is not (224, 224, 3).

--- a/larq_zoo/literature/xnornet.py
+++ b/larq_zoo/literature/xnornet.py
@@ -148,6 +148,12 @@ def XNORNet(
     /plots/xnornet.vg.json
     ```
 
+    # ImageNet Metrics
+    Top-1 Accuracy: 44.96 %
+    Top-5 Accuracy: 69.18 %
+    Parameters: 62 396 768
+    Memory: 22.81 MB
+
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
         with an input image resolution that is not (224, 224, 3).

--- a/larq_zoo/literature/xnornet.py
+++ b/larq_zoo/literature/xnornet.py
@@ -149,10 +149,9 @@ def XNORNet(
     ```
 
     # ImageNet Metrics
-    Top-1 Accuracy: 44.96 %
-    Top-5 Accuracy: 69.18 %
-    Parameters: 62 396 768
-    Memory: 22.81 MB
+    | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
+    | -------------- | -------------- | ---------- | ------- |
+    | 44.96 %        | 69.18 %        | 62 396 768 | 22.81 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model

--- a/larq_zoo/literature/xnornet.py
+++ b/larq_zoo/literature/xnornet.py
@@ -149,6 +149,7 @@ def XNORNet(
     ```
 
     # ImageNet Metrics
+
     | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
     | -------------- | -------------- | ---------- | ------- |
     | 44.96 %        | 69.18 %        | 62 396 768 | 22.81 MB |

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -305,6 +305,12 @@ def QuickNet(
     quicknet-v0.2.0/quicknet.json
     ```
 
+    # ImageNet Metrics
+    Top-1 Accuracy: 58.6 %
+    Top-5 Accuracy: 81.0 %
+    Parameters: 10 518 528
+    Memory: 3.21 MB
+
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
         with an input image resolution that is not (224, 224, 3).
@@ -348,6 +354,12 @@ def QuickNetLarge(
     quicknet_large-v0.2.0/quicknet_large.json
     ```
 
+    # ImageNet Metrics
+    Top-1 Accuracy: 62.7 %
+    Top-5 Accuracy: 84.0 %
+    Parameters: 11 837 696
+    Memory: 4.56 MB
+
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
         with an input image resolution that is not (224, 224, 3).
@@ -390,6 +402,12 @@ def QuickNetXL(
     ```netron
     quicknet_xl-v0.1.0/quicknet_xl.json
     ```
+
+    # ImageNet Metrics
+    Top-1 Accuracy: 67.0 %
+    Top-5 Accuracy: 87.3 %
+    Parameters: 22 058 368
+    Memory: 6.22 MB
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -306,9 +306,10 @@ def QuickNet(
     ```
 
     # ImageNet Metrics
+
     | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
     | -------------- | -------------- | ---------- | ------- |
-    | 58.6 %        | 81.0 %        | 10 518 528 | 3.21 MB |
+    | 58.6 %         | 81.0 %         | 10 518 528 | 3.21 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
@@ -354,9 +355,10 @@ def QuickNetLarge(
     ```
 
     # ImageNet Metrics
+
     | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
     | -------------- | -------------- | ---------- | ------- |
-    | 62.7 %        | 84.0 %        | 11 837 696 | 4.56 MB |
+    | 62.7 %         | 84.0 %         | 11 837 696 | 4.56 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
@@ -402,9 +404,10 @@ def QuickNetXL(
     ```
 
     # ImageNet Metrics
+
     | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
     | -------------- | -------------- | ---------- | ------- |
-    | 67.0 %        | 87.3 %        | 22 058 368 | 6.22 MB |
+    | 67.0 %         | 87.3 %         | 22 058 368 | 6.22 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -306,10 +306,9 @@ def QuickNet(
     ```
 
     # ImageNet Metrics
-    Top-1 Accuracy: 58.6 %
-    Top-5 Accuracy: 81.0 %
-    Parameters: 10 518 528
-    Memory: 3.21 MB
+    | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
+    | -------------- | -------------- | ---------- | ------- |
+    | 58.6 %        | 81.0 %        | 10 518 528 | 3.21 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
@@ -355,10 +354,9 @@ def QuickNetLarge(
     ```
 
     # ImageNet Metrics
-    Top-1 Accuracy: 62.7 %
-    Top-5 Accuracy: 84.0 %
-    Parameters: 11 837 696
-    Memory: 4.56 MB
+    | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
+    | -------------- | -------------- | ---------- | ------- |
+    | 62.7 %        | 84.0 %        | 11 837 696 | 4.56 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model
@@ -404,10 +402,9 @@ def QuickNetXL(
     ```
 
     # ImageNet Metrics
-    Top-1 Accuracy: 67.0 %
-    Top-5 Accuracy: 87.3 %
-    Parameters: 22 058 368
-    Memory: 6.22 MB
+    | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
+    | -------------- | -------------- | ---------- | ------- |
+    | 67.0 %        | 87.3 %        | 22 058 368 | 6.22 MB |
 
     # Arguments
     input_shape: Optional shape tuple, to be specified if you would like to use a model


### PR DESCRIPTION
Fixes #125 


This PR adds model metrics from [the documentation](https://docs.larq.dev/zoo/#available-models) to model docstrings.

The format use is:
```
# ImageNet Metrics
Top-1 Accuracy: 36.30 %
Top-5 Accuracy: 61.53 %
Parameters: 61 859 192
Memory: 7.49 MB
``` 

Let me know if there is a more suitable format to use.