### PR TITLE
Upload coverage report without token

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -30,6 +30,4 @@ jobs:
         run: pytest . -n auto --cov=larq_zoo --cov-report=xml --cov-config=.coveragerc
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.7' && matrix.tf-version == '2.0.1'
-        run: curl -s https://codecov.io/bash | bash -s -- -t $token -f ./coverage.xml -F unittests
-        env:
-          token: ${{secrets.CODECOV_TOKEN}}
+        run: curl -s https://codecov.io/bash | bash -s -- -f ./coverage.xml -F unittests


### PR DESCRIPTION
CodeCov has whitelisted GitHub actions to upload coverage reports without a token. This allows the coverage to be reported from Pull requests from forks as well. Currently codecov doesn't report back when opening a PR from a fork. See #145