### PR TITLE
Only publish releases on pypi that start with v*

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    if: github.event_name == "release" && startsWith(github.event.release.tag_name, "v")
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7


### PR DESCRIPTION
Note that I didn't test this, but based on the GitHub documentation this should fix our issues.