### PR TITLE
Add test to ensure that notop-weight are correct

### DIFF
--- a/larq_zoo/literature/binary_alex_net.py
+++ b/larq_zoo/literature/binary_alex_net.py
@@ -98,9 +98,9 @@ class BinaryAlexNetFactory(ModelFactory):
             else:
                 weights_path = utils.download_pretrained_model(
                     model="binary_alexnet",
-                    version="v0.2.0",
+                    version="v0.2.1",
                     file="binary_alexnet_weights_notop.h5",
-                    file_hash="1c7e2ef156edd8e7615e75a3b8929f9025279a948d1911824c2f5a798042475e",
+                    file_hash="1d41b33ff39cd28d13679392641bf7711174a96d182417f91df45d0548f5bb47",
                 )
             model.load_weights(weights_path)
         elif self.weights is not None:

--- a/larq_zoo/literature/densenet.py
+++ b/larq_zoo/literature/densenet.py
@@ -192,9 +192,9 @@ class BinaryDenseNet37DilatedFactory(BinaryDenseNetFactory):
     def imagenet_no_top_weights_path(self):
         return utils.download_pretrained_model(
             model="binary_densenet",
-            version="v0.1.0",
+            version="v0.1.1",
             file="binary_densenet_37_dilated_weights_notop.h5",
-            file_hash="eaf3eac19fc90708f56a27435fb06d0e8aef40e6e0411ff7a8eefbe479226e4f",
+            file_hash="8b31fbfdc8de08a46c6adcda1ced48ace0a2ff0ce45a05c72b2acc27901dd88b",
         )
 
 

--- a/larq_zoo/literature/dorefanet.py
+++ b/larq_zoo/literature/dorefanet.py
@@ -112,9 +112,9 @@ class DoReFaNetFactory(ModelFactory):
             else:
                 weights_path = utils.download_pretrained_model(
                     model="dorefanet",
-                    version="v0.1.0",
+                    version="v0.1.1",
                     file="dorefanet_weights_notop.h5",
-                    file_hash="679368128e19a2a181bfe06ca3a3dec368b1fd8011d5f42647fbbf5a7f36d45f",
+                    file_hash="8650e8a86d8d3968722cf5f20bcebe74d6d7bb45bbf03c4bb8c6486343f37e31",
                 )
             model.load_weights(weights_path)
         elif self.weights is not None:

--- a/larq_zoo/literature/meliusnet.py
+++ b/larq_zoo/literature/meliusnet.py
@@ -209,9 +209,9 @@ class MeliusNet22Factory(MeliusNetFactory):
     def imagenet_no_top_weights_path(self):
         return utils.download_pretrained_model(
             model="meliusnet22",
-            version="v0.1.0",
+            version="v0.1.1",
             file="meliusnet22_weights_notop.h5",
-            file_hash="b64c8296a3d07ce2799846caf0ad6d390f6cd9bbf21ea3390fafbab87bb79aa5",
+            file_hash="abfc5c50049d72a14e44df0c1cb73896ece2a1ab4bf9bb48fede6cc2f5e0b58f",
         )
 
 

--- a/larq_zoo/literature/xnornet.py
+++ b/larq_zoo/literature/xnornet.py
@@ -119,9 +119,9 @@ class XNORNetFactory(ModelFactory):
             else:
                 weights_path = utils.download_pretrained_model(
                     model="xnornet",
-                    version="v0.2.0",
+                    version="v0.2.1",
                     file="xnornet_weights_notop.h5",
-                    file_hash="0b8e3d0d60a7a728b5e387b8cd9f0fedc1dd72bcf9f4c693a2245d3a3c596b91",
+                    file_hash="20a17423090b2c80c6b7a6b62346faa4b2b7dc8d4da99efa792c9351cf86c3d5",
                 )
             model.load_weights(weights_path)
         elif self.weights is not None:

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -215,18 +215,18 @@ class QuickNetFactory(QuickNetBaseFactory):
     def imagenet_weights_path(self):
         return utils.download_pretrained_model(
             model="quicknet",
-            version="v0.2.0",
+            version="v0.2.1",
             file="quicknet_weights.h5",
-            file_hash="6a765f120ba7b62a7740e842c4f462eb7ba3dd65eb46b4694c5bc8169618fae7",
+            file_hash="7b4fa94f5241c7aad3412ca42b5db6517dbc4847cff710cb82be10c2f83bc0be",
         )
 
     @property
     def imagenet_no_top_weights_path(self):
         return utils.download_pretrained_model(
             model="quicknet",
-            version="v0.2.0",
+            version="v0.2.1",
             file="quicknet_weights_notop.h5",
-            file_hash="5bf2fc450fb8cc322b33a16410bf88fed09d05c221550c2d5805a04985383ac2",
+            file_hash="359eed6dae43525eddf520ea87ec9b54750ee0e022647775d115a38856be396f",
         )
 
 

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -279,18 +279,18 @@ class QuickNetXLFactory(QuickNetBaseFactory):
     def imagenet_weights_path(self):
         return utils.download_pretrained_model(
             model="quicknet_xl",
-            version="v0.1.0",
+            version="v0.1.1",
             file="quicknet_xl_weights.h5",
-            file_hash="a85eea1204fa9a8401f922f94531858493e3518e3374347978ed7ba615410498",
+            file_hash="19a41e753dbd4fbc3cbdaecd3627fb536ef55d64702996aae3875a8de3cf8073",
         )
 
     @property
     def imagenet_no_top_weights_path(self):
         return utils.download_pretrained_model(
             model="quicknet_xl",
-            version="v0.1.0",
+            version="v0.1.1",
             file="quicknet_xl_weights_notop.h5",
-            file_hash="b97074d6618acde4201d1f8676d32272d27743ddfe27c6c97e4516511ebb5008",
+            file_hash="ad5cbfa333b0aabde75dc524c9ce4a5ae096061da0e2dcf362ec6e587a83a511",
         )
 
 

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -247,18 +247,18 @@ class QuickNetLargeFactory(QuickNetBaseFactory):
     def imagenet_weights_path(self):
         return utils.download_pretrained_model(
             model="quicknet_large",
-            version="v0.2.0",
+            version="v0.2.1",
             file="quicknet_large_weights.h5",
-            file_hash="2d9ebbf8ba0500552e4dd243c3e52fd8291f965ef6a0e1dbba13cc72bf6eee8b",
+            file_hash="6bf778e243466c678d6da0e3a91c77deec4832460046fca9e6ac8ae97a41299c",
         )
 
     @property
     def imagenet_no_top_weights_path(self):
         return utils.download_pretrained_model(
             model="quicknet_large",
-            version="v0.2.0",
+            version="v0.2.1",
             file="quicknet_large_weights_notop.h5",
-            file_hash="067655ef8a1a1e99ef1c71fa775c09aca44bdfad0b9b71538b4ec500c3beee4f",
+            file_hash="b65d59dd2d5af63d019997b05faff9e003510e2512aa973ee05eb1b82b8792a9",
         )
 
 

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -61,6 +61,10 @@ def test_prediction(app, last_feature_dim):
     names = [p[1] for p in lqz.decode_predictions(preds, top=3)[0]]
     assert "African_elephant" in names
 
+    notop_model = app(weights="imagenet", include_top=False)
+    for weight, notop_weight in zip(model.get_weights(), notop_model.get_weights()):
+        np.testing.assert_allclose(notop_weight, weight)
+
 
 @parametrize
 def test_basic(app, last_feature_dim):


### PR DESCRIPTION
This PR adds a check to ensure that weights of the notop model are correct.

This test currently fails on the following models:
- [x] BinaryAlexNet
- [x] BinaryDenseNet37Dilated
- [x] MeliusNet22
- [x] DoReFaNet
- [x] XNORNet
- [x] QuickNet
- [x] QuickNetLarge
- [x] QuickNetXL