### PR TITLE
Fix dataset mocking for TensorFlow 3.1.0

### DIFF
--- a/larq_zoo/training/data.py
+++ b/larq_zoo/training/data.py
@@ -50,10 +50,6 @@ class Default(ImageClassification):
 
     def input(self, data, training):
         image = data["image"]
-        # tfds.testing.mock_data currently doesn't correctly handle custom decoders.
-        # See https://github.com/tensorflow/datasets/pull/1861
-        if image.dtype.is_integer:
-            image = tf.image.encode_jpeg(image)
         return preprocess_image_bytes(
             image, is_training=training, image_size=IMAGE_SIZE
         )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
             "pytest-xdist==1.31.0",
             "Pillow==7.1.2",
             "scipy==1.4.1",
-            "tensorflow_datasets>=1.3.0,<3.1.0",  # TFDS 3.1.0 breaks dataset mocking.
+            "tensorflow_datasets>=3.1.0",
         ],
     },
     entry_points="""

--- a/tests/train_test.py
+++ b/tests/train_test.py
@@ -8,12 +8,19 @@ from zookeeper.tf.dataset import TFDSDataset
 from larq_zoo.training import basic_experiments, multi_stage_experiments
 
 
+# tfds doesn't correctly set the encoding_format for some datasets and defaults to png.
+# This breaks mocking and preprocessing so we hardcode it to jpeg in the unittests.
+def set_encoding_format(self, encoding_format):
+    self._encoding_format = "jpeg"
+
+
 @pytest.mark.parametrize(
     "command",
     [e for e in list(basic_experiments.cli.commands.keys()) if "R2B" not in e],
 )
 @tfds.testing.mock_data(num_examples=2, data_dir="gs://tfds-data/dataset_info")
 @mock.patch.object(TFDSDataset, "num_examples", return_value=2)
+@mock.patch.object(tfds.core.features.Image, "set_encoding_format", set_encoding_format)
 def test_cli(_, command):
     result = CliRunner().invoke(
         basic_experiments.cli,
@@ -37,6 +44,7 @@ def test_cli(_, command):
 )
 @tfds.testing.mock_data(num_examples=2, data_dir="gs://tfds-data/dataset_info")
 @mock.patch.object(TFDSDataset, "num_examples", return_value=2)
+@mock.patch.object(tfds.core.features.Image, "set_encoding_format", set_encoding_format)
 def test_multi_stage_experiments(_, command, phases):
     arguments = [command]
     for phase in range(phases):


### PR DESCRIPTION
tfds doesn't correctly set the `encoding_format` for some datasets and defaults to `png` instead. This breaks mocking and preprocessing so we hardcode it to `jpeg` in the unittests.