### PR TITLE
Reformat docs for keras-autodoc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,9 @@ Install all required dependencies for local development by running:
 
 ```shell
 cd larq-zoo # go into the directory you just cloned
-pip install -e .[tensorflow] # Installs Tensorflow for CPU
-# pip install -e .[tensorflow_gpu] # Installs Tensorflow for GPU
-pip install -e .[test] # Installs all development dependencies
+pip install -e ".[tensorflow]" # Installs Tensorflow for CPU
+# pip install -e ".[tensorflow_gpu]" # Installs Tensorflow for GPU
+pip install -e ".[test]" # Installs all development dependencies
 ```
 
 ## Run Unit tests

--- a/larq_zoo/core/utils.py
+++ b/larq_zoo/core/utils.py
@@ -112,19 +112,19 @@ def global_pool(
     GlobalAveragePooling2D.
 
     # Arguments
-    x: 4D TensorFlow tensor.
-    data_format: A string, one of channels_last (default) or
-        channels_first. The ordering of the dimensions in the inputs. channels_last
-        corresponds to inputs with shape (batch, height, width, channels) while
-        channels_first corresponds to inputs with shape (batch, channels, height,
-        width). It defaults to "channels_last".
-    name: String name of the layer
+        x: 4D TensorFlow tensor.
+        data_format: A string, one of channels_last (default) or
+            channels_first. The ordering of the dimensions in the inputs. channels_last
+            corresponds to inputs with shape (batch, height, width, channels) while
+            channels_first corresponds to inputs with shape (batch, channels, height,
+            width). It defaults to "channels_last".
+        name: String name of the layer
 
     # Returns
-    2D TensorFlow tensor.
+        2D TensorFlow tensor.
 
     # Raises
-    ValueError: if tensor is not 4D or data_format is not recognized.
+        ValueError: if tensor is not 4D or data_format is not recognized.
     """
     if len(x.get_shape()) != 4:
         raise ValueError("Tensor is not 4D.")
@@ -154,16 +154,16 @@ def decode_predictions(preds, top=5, **kwargs):
     """Decodes the prediction of an ImageNet model.
 
     # Arguments
-    preds: Numpy tensor encoding a batch of predictions.
-    top: Integer, how many top-guesses to return.
+        preds: Numpy tensor encoding a batch of predictions.
+        top: Integer, how many top-guesses to return.
 
     # Returns
-    A list of lists of top class prediction tuples
-        `(class_name, class_description, score)`.
-        One list of tuples per sample in batch input.
+        A list of lists of top class prediction tuples
+            `(class_name, class_description, score)`.
+            One list of tuples per sample in batch input.
 
     # Raises
-    ValueError: In case of invalid shape of the `pred` array (must be 2D).
+        ValueError: In case of invalid shape of the `pred` array (must be 2D).
     """
     return tf.keras.applications.vgg16.decode_predictions(preds, top=top, **kwargs)
 
@@ -175,11 +175,10 @@ def TFOpLayer(tf_op: tf.Operation, *args, **kwargs) -> tf.keras.layers.Layer:
     Example: `TFOpLayer(tf.split, groups, axis=-1, name="split")(x)`.
 
     # Arguments
-    tf_op: tensorflow that needs to be wrapped.
+        tf_op: tensorflow that needs to be wrapped.
 
     # Returns
-    A keras layer wrapping `tf_op`.
-
+        A keras layer wrapping `tf_op`.
     """
     name = kwargs.pop("name", None)
     return tf.keras.layers.Lambda(lambda x_: tf_op(x_, *args, **kwargs), name=name)

--- a/larq_zoo/literature/binary_alex_net.py
+++ b/larq_zoo/literature/binary_alex_net.py
@@ -138,22 +138,24 @@ def BinaryAlexNet(
     | 36.30 %        | 61.53 %        | 61 859 192 | 7.49 MB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be
-        specified if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
     """
     return BinaryAlexNetFactory(
         input_shape=input_shape,

--- a/larq_zoo/literature/birealnet.py
+++ b/larq_zoo/literature/birealnet.py
@@ -144,27 +144,29 @@ def BiRealNet(
     | 57.47 %        | 79.84 %        | 11 699 112 | 4.03 MB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be
-        specified if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
 
     # References
-    - [Bi-Real Net: Enhancing the Performance of 1-bit CNNs With Improved
-      Representational Capability and Advanced Training
-      Algorithm](https://arxiv.org/abs/1808.00278)
+        - [Bi-Real Net: Enhancing the Performance of 1-bit CNNs With Improved
+            Representational Capability and Advanced Training
+            Algorithm](https://arxiv.org/abs/1808.00278)
     """
     return BiRealNetFactory(
         include_top=include_top,

--- a/larq_zoo/literature/densenet.py
+++ b/larq_zoo/literature/densenet.py
@@ -266,26 +266,28 @@ def BinaryDenseNet28(
     | 60.91 %        | 82.83 %        | 5 150 504  | 4.12 MB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be specified
-        if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
 
     # References
-    - [Back to Simplicity:
-      How to Train Accurate BNNs from Scratch?](https://arxiv.org/abs/1906.08637)
+        - [Back to Simplicity: How to Train Accurate BNNs from
+            Scratch?](https://arxiv.org/abs/1906.08637)
     """
     return BinaryDenseNet28Factory(
         input_shape=input_shape,
@@ -325,26 +327,28 @@ def BinaryDenseNet37(
     | 62.89 %        | 84.19 %        | 8 734 120  | 5.25 MB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be specified
-        if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
 
     # References
-    - [Back to Simplicity:
-      How to Train Accurate BNNs from Scratch?](https://arxiv.org/abs/1906.08637)
+        - [Back to Simplicity: How to Train Accurate BNNs from
+            Scratch?](https://arxiv.org/abs/1906.08637)
     """
     return BinaryDenseNet37Factory(
         input_shape=input_shape,
@@ -384,26 +388,28 @@ def BinaryDenseNet37Dilated(
     | 64.34 %        | 85.15 %        | 8 734 120  | 5.25 MB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be specified
-        if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
 
     # References
-    - [Back to Simplicity:
-      How to Train Accurate BNNs from Scratch?](https://arxiv.org/abs/1906.08637)
+        - [Back to Simplicity: How to Train Accurate BNNs from
+            Scratch?](https://arxiv.org/abs/1906.08637)
     """
     return BinaryDenseNet37DilatedFactory(
         input_shape=input_shape,
@@ -443,26 +449,28 @@ def BinaryDenseNet45(
     | 64.59 %        | 85.21 %        | 13 939 240 | 7.54 MB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be specified
-        if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
 
     # References
-    - [Back to Simplicity:
-      How to Train Accurate BNNs from Scratch?](https://arxiv.org/abs/1906.08637)
+        - [Back to Simplicity: How to Train Accurate BNNs from
+            Scratch?](https://arxiv.org/abs/1906.08637)
     """
     return BinaryDenseNet45Factory(
         input_shape=input_shape,

--- a/larq_zoo/literature/dorefanet.py
+++ b/larq_zoo/literature/dorefanet.py
@@ -155,26 +155,28 @@ def DoReFaNet(
     | 53.39 %        | 76.50 %        | 62 403 912 | 22.84 MB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be
-        specified if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
 
     # References
-    - [DoReFa-Net: Training Low Bitwidth Convolutional Neural Networks with Low
-    Bitwidth Gradients](https://arxiv.org/abs/1606.06160)
+        - [DoReFa-Net: Training Low Bitwidth Convolutional Neural Networks with Low
+            Bitwidth Gradients](https://arxiv.org/abs/1606.06160)
     """
     return DoReFaNetFactory(
         input_shape=input_shape,

--- a/larq_zoo/literature/meliusnet.py
+++ b/larq_zoo/literature/meliusnet.py
@@ -258,25 +258,28 @@ def MeliusNet22(
     | 62.4 %         | 83.9 %         | 6 944 584  | 3.88 MiB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be
-        specified if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
 
     # References
-    - [MeliusNet: Can Binary Neural Networks Achieve MobileNet-level Accuracy?](https://arxiv.org/abs/2001.05936)
+        - [MeliusNet: Can Binary Neural Networks Achieve MobileNet-level
+            Accuracy?](https://arxiv.org/abs/2001.05936)
     """
     return MeliusNet22Factory(
         include_top=include_top,

--- a/larq_zoo/literature/real_to_bin_nets.py
+++ b/larq_zoo/literature/real_to_bin_nets.py
@@ -452,26 +452,28 @@ def RealToBinaryNet(
     | 65.01 %        | 85.72 %        | 11 995 624 | 5.13 MB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be
-        specified if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
 
     # References
-    - [Training binary neural networks with
-        real-to-binary convolutions](https://openreview.net/forum?id=BJg4NgBKvH)
+        - [Training binary neural networks with real-to-binary
+            convolutions](https://openreview.net/forum?id=BJg4NgBKvH)
     """
     return RealToBinNetBNNFactory(
         input_shape=input_shape,

--- a/larq_zoo/literature/resnet_e.py
+++ b/larq_zoo/literature/resnet_e.py
@@ -172,26 +172,28 @@ def BinaryResNetE18(
     | 58.32 %        | 80.79 %        | 11 699 368 | 4.03 MB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be specified
-        if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
 
     # References
-    - [Back to Simplicity:
-      How to Train Accurate BNNs from Scratch?](https://arxiv.org/abs/1906.08637)
+        - [Back to Simplicity: How to Train Accurate BNNs from
+            Scratch?](https://arxiv.org/abs/1906.08637)
     """
     return BinaryResNetE18Factory(
         input_shape=input_shape,

--- a/larq_zoo/literature/xnornet.py
+++ b/larq_zoo/literature/xnornet.py
@@ -154,26 +154,28 @@ def XNORNet(
     | 44.96 %        | 69.18 %        | 62 396 768 | 22.81 MB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be specified
-        if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
 
     # References
-    - [XNOR-Net: ImageNet Classification Using Binary Convolutional Neural
-      Networks](https://arxiv.org/abs/1603.05279)
+        - [XNOR-Net: ImageNet Classification Using Binary Convolutional Neural
+            Networks](https://arxiv.org/abs/1603.05279)
     """
     return XNORNetFactory(
         input_shape=input_shape,

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -328,22 +328,24 @@ def QuickNet(
     | 58.6 %         | 81.0 %         | 10 518 528 | 3.21 MB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be specified
-        if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
     """
     return QuickNetFactory(
         input_shape=input_shape,
@@ -380,22 +382,24 @@ def QuickNetLarge(
     | 62.7 %         | 84.0 %         | 11 837 696 | 4.56 MB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be specified
-        if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
     """
     return QuickNetLargeFactory(
         input_shape=input_shape,
@@ -432,22 +436,24 @@ def QuickNetXL(
     | 67.0 %         | 87.3 %         | 22 058 368 | 6.22 MB |
 
     # Arguments
-    input_shape: Optional shape tuple, to be specified if you would like to use a model
-        with an input image resolution that is not (224, 224, 3).
-        It should have exactly 3 inputs channels.
-    input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
-        image input for the model.
-    weights: one of `None` (random initialization), "imagenet" (pre-training on
-        ImageNet), or the path to the weights file to be loaded.
-    include_top: whether to include the fully-connected layer at the top of the network.
-    num_classes: optional number of classes to classify images into, only to be specified
-        if `include_top` is True, and if no `weights` argument is specified.
+        input_shape: Optional shape tuple, to be specified if you would like to use a
+            model with an input image resolution that is not (224, 224, 3).
+            It should have exactly 3 inputs channels.
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as
+            image input for the model.
+        weights: one of `None` (random initialization), "imagenet" (pre-training on
+            ImageNet), or the path to the weights file to be loaded.
+        include_top: whether to include the fully-connected layer at the top of the
+            network.
+        num_classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
 
     # Returns
-    A Keras model instance.
+        A Keras model instance.
 
     # Raises
-    ValueError: in case of invalid argument for `weights`, or invalid input shape.
+        ValueError: in case of invalid argument for `weights`, or invalid input shape.
     """
     return QuickNetXLFactory(
         input_shape=input_shape,

--- a/larq_zoo/training/data.py
+++ b/larq_zoo/training/data.py
@@ -21,10 +21,10 @@ def preprocess_input(image):
     """Preprocesses a Tensor or Numpy array encoding a image.
 
     # Arguments
-    image: Numpy array or symbolic Tensor, 3D.
+        image: Numpy array or symbolic Tensor, 3D.
 
     # Returns
-    Preprocessed Tensor or Numpy array.
+        Preprocessed Tensor or Numpy array.
     """
     if len(image.shape) != 3:
         raise ValueError("Input must be of size [height, width, C>0]")


### PR DESCRIPTION
This adds indentations to docstrings so that [keras-autodoc](https://github.com/keras-team/keras-autodoc) understands sections with lists of arguments, input shapes, output shapes, returns, etc. See larq/docs#68.

Before:

```
# Arguments:
arg_name: this is the description.
```

After:

```
# Arguments:
    arg_name: this is the description.
```

We'll probably need to do a minor release of Zoo once we do this, and then bump the version that larq/docs uses to that version. 