### PR TITLE
Fix entry point

### DIFF
--- a/larq_zoo/training/main.py
+++ b/larq_zoo/training/main.py
@@ -1,9 +1,13 @@
 import importlib
 
+
 def cli():
-    for experiments_file in ('larq_zoo.training.basic_experiments', 'larq_zoo.training.multi_stage_experiments'):
+    for experiments_file in (
+        "larq_zoo.training.basic_experiments",
+        "larq_zoo.training.multi_stage_experiments",
+    ):
         importlib.import_module(experiments_file)
-    
+
     from zookeeper import cli
 
     cli()

--- a/larq_zoo/training/main.py
+++ b/larq_zoo/training/main.py
@@ -1,0 +1,13 @@
+import importlib
+
+def cli():
+    for experiments_file in ('larq_zoo.training.basic_experiments', 'larq_zoo.training.multi_stage_experiments'):
+        importlib.import_module(experiments_file)
+    
+    from zookeeper import cli
+
+    cli()
+
+
+if __name__ == "__main__":
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     },
     entry_points="""
         [console_scripts]
-        lqz=larq_zoo.experiments:cli
+        lqz=larq_zoo.training.main:cli
     """,
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
The console entry point defined in setup.py currently does not exist anymore. This adds a new one that makes the experiments from `basic_experiments` and those from `multi_stage_experiments` available.