### PR TITLE
Cleanup tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
             "pytype>=2019.10.17,<2020.7.0",
             "pytest>=4.3.1",
             "pytest-cov>=2.6.1",
+            "pytest-mock>=3.1.1",
             "pytest-xdist==1.32.0",
             "Pillow==7.1.2",
             "scipy==1.4.1",

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,24 +1,17 @@
+import pytest
 import tensorflow as tf
 
 from larq_zoo.core import utils
 
 
-def test_global_pool():
-    def build_model(input_res=(32, 32), data_format="channels_first"):
-        if data_format == "channels_first":
-            input_shape = (3, input_res[0], input_res[1])
-        else:
-            input_shape = (input_res[0], input_res[1], 3)
-        inp = tf.keras.Input(shape=input_shape)
-        x = tf.keras.layers.Conv2D(6, 3, 2, data_format=data_format)(inp)
-        x = utils.global_pool(x, data_format=data_format)
-        x = tf.keras.layers.Dense(2)(x)
-        return tf.keras.Model(inputs=inp, outputs=x)
+@pytest.mark.parametrize("data_format", ["channels_last", "channels_first"])
+@pytest.mark.parametrize("input_res", [(32, 32), (None, 32)])
+def test_global_pool(input_res, data_format):
+    shape = (3, *input_res) if data_format == "channels_first" else (*input_res, 3)
+    inp = tf.keras.Input(shape=shape)
+    x = tf.keras.layers.Conv2D(6, 3, 2, data_format=data_format)(inp)
+    x = utils.global_pool(x, data_format=data_format)
+    x = tf.keras.layers.Dense(2)(x)
+    model = tf.keras.Model(inp, x)
 
-    for data_format in ["channels_first", "channels_last"]:
-        fixed_model = build_model()
-        dynamic_model = build_model(input_res=(None, 32))
-
-        for model in [fixed_model, dynamic_model]:
-            output_shape = model.outputs[0].get_shape().as_list()
-            assert output_shape == [None, 2]
+    assert model.outputs[0].shape.as_list() == [None, 2]


### PR DESCRIPTION
This PR cleansup some of our tests by relying on pytest fixtures and parametrized tests. This also fixes a bug in the global pooling test where `data_format="channels_last"` was never tested.