### PR TITLE
Add QuickNet v1 architecture

### DIFF
--- a/larq_zoo/sota/__init__.py
+++ b/larq_zoo/sota/__init__.py
@@ -1,3 +1,3 @@
-from larq_zoo.sota.quicknet import QuickNet, QuickNetLarge, QuickNetXL
+from larq_zoo.sota.quicknet import QuickNet, QuickNetLarge, QuickNetSmall
 
-__all__ = ["QuickNet", "QuickNetLarge", "QuickNetXL"]
+__all__ = ["QuickNet", "QuickNetLarge", "QuickNetSmall"]

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -246,6 +246,9 @@ def QuickNet(
     ```summary
     sota.QuickNet
     ```
+    ```plot-altair
+    /plots/quicknet.vg.json
+    ```
 
     # ImageNet Metrics
 
@@ -300,6 +303,9 @@ def QuickNetLarge(
     ```summary
     sota.QuickNetLarge
     ```
+    ```plot-altair
+    /plots/quicknet_large.vg.json
+    ```
 
     # ImageNet Metrics
 
@@ -353,6 +359,9 @@ def QuickNetSmall(
     ```
     ```summary
     sota.QuickNetSmall
+    ```
+    ```plot-altair
+    /plots/quicknet_small.vg.json
     ```
 
     # ImageNet Metrics

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -98,27 +98,6 @@ class QuickNetFactory(ModelFactory):
         )(x)
         return tf.keras.layers.BatchNormalization()(x)
 
-    def conv_block(
-        self,
-        x: tf.Tensor,
-        filters: int,
-        strides: int = 1,
-    ) -> tf.Tensor:
-        x = lq.layers.QuantConv2D(
-            filters,
-            (3, 3),
-            activation="relu",
-            input_quantizer=self.input_quantizer,
-            kernel_constraint=self.kernel_constraint,
-            kernel_quantizer=self.kernel_quantizer,
-            kernel_initializer="glorot_normal",
-            padding="same",
-            pad_values=1.0,
-            strides=strides,
-            use_bias=False,
-        )(x)
-        return tf.keras.layers.BatchNormalization(momentum=0.9, epsilon=1e-5)(x)
-
     def residual_block(self, x: tf.Tensor) -> tf.Tensor:
         """Standard residual block, without strides or filter changes."""
 

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -40,7 +40,7 @@ class QuickNetFactory(ModelFactory):
             model="quicknet",
             version="v1.0.0",
             file="quicknet_weights.h5",
-            file_hash="7b4fa94f5241c7aad3412ca42b5db6517dbc4847cff710cb82be10c2f83bc0be",
+            file_hash="8aba9e4e5f8d342faef04a0b2ae8e562da57dbb7d15162e8b3e091c951ba756c",
         )
 
     @property
@@ -49,7 +49,7 @@ class QuickNetFactory(ModelFactory):
             model="quicknet",
             version="v1.0.0",
             file="quicknet_weights_notop.h5",
-            file_hash="359eed6dae43525eddf520ea87ec9b54750ee0e022647775d115a38856be396f",
+            file_hash="204414e438373f14f6056a1c098249f505a87dd238e18d3a47a9bd8b66227881",
         )
 
     @property
@@ -188,19 +188,19 @@ class QuickNetSmallFactory(QuickNetFactory):
     @property
     def imagenet_weights_path(self):
         return utils.download_pretrained_model(
-            model="quicknet_small",
+            model="quicknet",
             version="v1.0.0",
             file="quicknet_small_weights.h5",
-            file_hash="6bf778e243466c678d6da0e3a91c77deec4832460046fca9e6ac8ae97a41299c",
+            file_hash="1ac3b07df7f5a911dd0b49febb2486428ddf1ca130297c403815dfae5a1c71a2",
         )
 
     @property
     def imagenet_no_top_weights_path(self):
         return utils.download_pretrained_model(
-            model="quicknet_small",
+            model="quicknet",
             version="v1.0.0",
             file="quicknet_small_weights_notop.h5",
-            file_hash="b65d59dd2d5af63d019997b05faff9e003510e2512aa973ee05eb1b82b8792a9",
+            file_hash="be8ba657155846be355c5580d1ea56eaf8282616de065ffc39257202f9f164ea",
         )
 
 
@@ -212,19 +212,19 @@ class QuickNetLargeFactory(QuickNetFactory):
     @property
     def imagenet_weights_path(self):
         return utils.download_pretrained_model(
-            model="quicknet_large",
+            model="quicknet",
             version="v1.0.0",
             file="quicknet_large_weights.h5",
-            file_hash="6bf778e243466c678d6da0e3a91c77deec4832460046fca9e6ac8ae97a41299c",
+            file_hash="c5158e8a59147b31370becd937825f4db8a5cdf308314874f678f596629be45c",
         )
 
     @property
     def imagenet_no_top_weights_path(self):
         return utils.download_pretrained_model(
-            model="quicknet_large",
+            model="quicknet",
             version="v1.0.0",
             file="quicknet_large_weights_notop.h5",
-            file_hash="b65d59dd2d5af63d019997b05faff9e003510e2512aa973ee05eb1b82b8792a9",
+            file_hash="adcf154a2a8007e81bd6af77c035ffbf54cd6413b89a0ba294e23e76a82a1b78",
         )
 
 
@@ -295,7 +295,7 @@ def QuickNetLarge(
     Optionally loads weights pre-trained on ImageNet.
 
     ```netron
-    quicknet_large-v1.0.0/quicknet_large.json
+    quicknet-v1.0.0/quicknet_large.json
     ```
     ```summary
     sota.QuickNetLarge
@@ -349,7 +349,7 @@ def QuickNetSmall(
     Optionally loads weights pre-trained on ImageNet.
 
     ```netron
-    quicknet_small-v1.0.0/quicknet_small.json
+    quicknet-v1.0.0/quicknet_small.json
     ```
     ```summary
     sota.QuickNetSmall

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -316,7 +316,7 @@ def QuickNetLarge(
 
     | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
     | -------------- | -------------- | ---------- | ------- |
-    | 66.0 %         | 87.0 %         | 23 342 248 | 5.40 MB |
+    | 66.9 %         | 87.0 %         | 23 342 248 | 5.40 MB |
 
     # Arguments
         input_shape: Optional shape tuple, to be specified if you would like to use a

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -10,6 +10,11 @@ from larq_zoo.core.model_factory import ModelFactory
 
 
 def blurpool_initializer(shape, dtype=None):
+    """Initializer for anti-aliased pooling.
+
+    # References
+        - [Making Convolutional Networks Shift-Invariant Again](https://arxiv.org/abs/1904.11486)
+    """
     ksize, filters = shape[0], shape[2]
 
     if ksize == 2:

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -153,8 +153,7 @@ class QuickNetFactory(ModelFactory):
         ):
             for layer in range(layers):
                 if filters != x.shape[-1]:
-                    strides = 1 if (block == 0 or layer != 0) else 2
-                    x = self.transition_block(x, filters, strides)
+                    x = self.transition_block(x, filters, strides=2)
                 x = self.residual_block(x)
 
         if self.include_top:

--- a/larq_zoo/training/learning_schedules.py
+++ b/larq_zoo/training/learning_schedules.py
@@ -53,17 +53,18 @@ class CosineDecayWithWarmup(tf.keras.optimizers.schedules.LearningRateSchedule):
 
         self.warm_up_schedule = tf.keras.optimizers.schedules.PolynomialDecay(
             initial_learning_rate=0.0,
-            decay_steps=warmup_steps,
+            decay_steps=warmup_steps - 1,
             end_learning_rate=max_learning_rate,
             power=1.0,
         )
         self.decay_schedule = tf.keras.experimental.CosineDecay(
-            initial_learning_rate=max_learning_rate, decay_steps=decay_steps
+            initial_learning_rate=max_learning_rate,
+            decay_steps=decay_steps - warmup_steps - 1,
         )
 
     def __call__(self, step):
         return tf.cond(
-            step <= self.warmup_steps,
+            step < self.warmup_steps,
             lambda: self.warm_up_schedule(step),
             lambda: self.decay_schedule(step - self.warmup_steps),
         )

--- a/larq_zoo/training/main.py
+++ b/larq_zoo/training/main.py
@@ -5,6 +5,7 @@ def cli():
     for experiments_file in (
         "larq_zoo.training.basic_experiments",
         "larq_zoo.training.multi_stage_experiments",
+        "larq_zoo.training.sota_experiments",
     ):
         importlib.import_module(experiments_file)
 

--- a/larq_zoo/training/multi_stage_experiments.py
+++ b/larq_zoo/training/multi_stage_experiments.py
@@ -87,7 +87,7 @@ class TrainFPResnet18(LarqZooModelTrainingPhase):
             CosineDecayWithWarmup(
                 max_learning_rate=self.learning_rate,
                 warmup_steps=self.warmup_duration * self.steps_per_epoch,
-                decay_steps=(self.epochs - self.warmup_duration) * self.steps_per_epoch,
+                decay_steps=self.epochs * self.steps_per_epoch,
             )
         )
     )
@@ -164,7 +164,7 @@ class TrainR2BBNNAlternative(TrainR2BBNN):
             CosineDecayWithWarmup(
                 max_learning_rate=self.learning_rate,
                 warmup_steps=self.steps_per_epoch * self.warmup_duration,
-                decay_steps=self.steps_per_epoch * (self.epochs - self.warmup_duration),
+                decay_steps=self.steps_per_epoch * self.epochs,
             )
         )
     )

--- a/larq_zoo/training/sota_experiments.py
+++ b/larq_zoo/training/sota_experiments.py
@@ -1,0 +1,54 @@
+import larq as lq
+import tensorflow as tf
+from zookeeper import ComponentField, Field, cli, task
+
+from larq_zoo.sota.quicknet import (
+    QuickNetFactory,
+    QuickNetLargeFactory,
+    QuickNetSmallFactory,
+)
+from larq_zoo.training.learning_schedules import CosineDecayWithWarmup
+from larq_zoo.training.train import TrainLarqZooModel
+
+
+@task
+class TrainQuickNet(TrainLarqZooModel):
+    model = ComponentField(QuickNetFactory)
+    epochs = Field(600)
+    batch_size = Field(2048)
+
+    @Field
+    def optimizer(self):
+        binary_opt = tf.keras.optimizers.Adam(
+            learning_rate=CosineDecayWithWarmup(
+                max_learning_rate=1e-2,
+                warmup_steps=self.steps_per_epoch * 5,
+                decay_steps=self.steps_per_epoch * self.epochs,
+            )
+        )
+        fp_opt = tf.keras.optimizers.SGD(
+            learning_rate=CosineDecayWithWarmup(
+                max_learning_rate=0.1,
+                warmup_steps=self.steps_per_epoch * 5,
+                decay_steps=self.steps_per_epoch * self.epochs,
+            ),
+            momentum=0.9,
+        )
+        return lq.optimizers.CaseOptimizer(
+            (lq.optimizers.Bop.is_binary_variable, binary_opt),
+            default_optimizer=fp_opt,
+        )
+
+
+@task
+class TrainQuickNetSmall(TrainQuickNet):
+    model = ComponentField(QuickNetSmallFactory)
+
+
+@task
+class TrainQuickNetLarge(TrainQuickNet):
+    model = ComponentField(QuickNetLargeFactory)
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -36,9 +36,9 @@ def parametrize(func):
             (lqz.literature.XNORNet, 4096),
             (lqz.literature.DoReFaNet, 256),
             (lqz.literature.RealToBinaryNet, 512),
+            (lqz.sota.QuickNetSmall, 512),
             (lqz.sota.QuickNet, 512),
             (lqz.sota.QuickNetLarge, 512),
-            (lqz.sota.QuickNetXL, 512),
         ],
     )(func)
 

--- a/tests/train_test.py
+++ b/tests/train_test.py
@@ -3,7 +3,13 @@ import tensorflow_datasets as tfds
 from click.testing import CliRunner
 from zookeeper.tf.dataset import TFDSDataset
 
-from larq_zoo.training import basic_experiments, multi_stage_experiments
+from larq_zoo.training import (
+    basic_experiments,
+    multi_stage_experiments,
+    sota_experiments,
+)
+
+assert basic_experiments  # register literature training
 
 
 @pytest.fixture(autouse=True)
@@ -15,11 +21,11 @@ def automock(request, mocker):
 
 @pytest.mark.parametrize(
     "command",
-    [e for e in basic_experiments.cli.commands.keys() if "R2B" not in e],
+    [e for e in sota_experiments.cli.commands.keys() if "R2B" not in e],
 )
 def test_cli(command):
     result = CliRunner().invoke(
-        basic_experiments.cli,
+        sota_experiments.cli,
         [
             command,
             "dataset=ImageNet",


### PR DESCRIPTION
This PR adds a new version of QuickNet. I also renamed to models to `QuickNetSmall`, `QuickNet` and `QuickNetLarge` and added the simple training loop used to train the models.