### PR TITLE
Pin zookeeper@1.0.4 to fix CI

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Install dependencies
-        run: pip install tensorflow-cpu==2.3.1 zookeeper==1.0.4 -e .[test]
+        run: pip install tensorflow-cpu==2.3.1 https://github.com/larq/zookeeper/archive/master.zip -e .[test]
       - name: Test training with pytest
         run: pytest tests/train_test.py -n auto --cov=larq_zoo --cov-report=xml --cov-config=.coveragerc --cov-append
       - name: Upload coverage to Codecov

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Install dependencies
-        run: pip install tensorflow-cpu==2.3.1 -e .[test]
+        run: pip install tensorflow-cpu==2.3.1 zookeeper==1.0.4 -e .[test]
       - name: Test training with pytest
         run: pytest tests/train_test.py -n auto --cov=larq_zoo --cov-report=xml --cov-config=.coveragerc --cov-append
       - name: Upload coverage to Codecov


### PR DESCRIPTION
[CI on master currently fails](https://github.com/larq/zoo/runs/1487893011), looks like https://github.com/larq/zookeeper/pull/206 broke this since downgrading to `zookeeper@1.0.4` seems to fix the issue.