### PR TITLE
Fix bug when cloning QuickNet.

### DIFF
--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -9,6 +9,7 @@ from larq_zoo.core import utils
 from larq_zoo.core.model_factory import ModelFactory
 
 
+@lq.utils.register_keras_custom_object
 def blurpool_initializer(shape, dtype=None):
     """Initializer for anti-aliased pooling.
 


### PR DESCRIPTION
Register the blurpool_initializer as a Keras custom object.

Previously, using `tf.keras.models.clone_model` with a QuickNet model caused `ValueError: Unknown initializer:blurpool_initializer`.