### PR TITLE
Add version limits to dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ setup(
     packages=find_packages(),
     license="Apache 2.0",
     install_requires=[
-        "numpy~=1.15",
+        "numpy>=1.15.0,<1.21.0",
         "larq>=0.9.2,<0.12.0",
-        "zookeeper>=1.0",
+        "zookeeper>=1.0.0,<1.4.0",
         "importlib-metadata ~= 2.0 ; python_version<'3.8'",
     ],
     extras_require={
@@ -53,6 +53,7 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
@lgeiger I think this should prevent what happened with #303, and Dependabot will bump the version ceilings for us. But it means we'll know if new versions break things.