### PR TITLE
Use 1x1 convolutions to improve BinaryAlexNet latency on Compute Engine

### DIFF
--- a/larq_zoo/literature/binary_alex_net.py
+++ b/larq_zoo/literature/binary_alex_net.py
@@ -43,12 +43,12 @@ class BinaryAlexNetFactory(ModelFactory):
         )(x)
         if pool:
             x = tf.keras.layers.MaxPool2D(pool_size=3, strides=2)(x)
-        x = tf.keras.layers.BatchNormalization(scale=False, momentum=0.9)(x)
-        return x
+        return tf.keras.layers.BatchNormalization(scale=False, momentum=0.9)(x)
 
     def dense_block(self, x: tf.Tensor, units: int) -> tf.Tensor:
-        x = lq.layers.QuantDense(
+        x = lq.layers.QuantConv2D(
             units,
+            kernel_size=1,
             input_quantizer=self.input_quantizer,
             kernel_quantizer=self.kernel_quantizer,
             kernel_constraint=self.kernel_constraint,
@@ -75,10 +75,11 @@ class BinaryAlexNetFactory(ModelFactory):
 
         # Classifier
         if self.include_top:
-            out = tf.keras.layers.Flatten()(out)
+            out = tf.keras.layers.Reshape((1, 1, -1))(out)
             out = self.dense_block(out, units=4096)
             out = self.dense_block(out, units=4096)
             out = self.dense_block(out, self.num_classes)
+            out = tf.keras.layers.Flatten()(out)
             out = tf.keras.layers.Activation("softmax", dtype="float32")(out)
 
         model = tf.keras.models.Model(
@@ -91,9 +92,9 @@ class BinaryAlexNetFactory(ModelFactory):
             if self.include_top:
                 weights_path = utils.download_pretrained_model(
                     model="binary_alexnet",
-                    version="v0.2.0",
+                    version="v0.3.0",
                     file="binary_alexnet_weights.h5",
-                    file_hash="0f8d3f6c1073ef993e2e99a38f8e661e5efe385085b2a84b43a7f2af8500a3d3",
+                    file_hash="7fc065c47c5c1d92389e0bb988ce6df6a4fa09d803b866e2ba648069d6652d63",
                 )
             else:
                 weights_path = utils.download_pretrained_model(
@@ -122,7 +123,7 @@ def BinaryAlexNet(
     Optionally loads weights pre-trained on ImageNet.
 
     ```netron
-    binary_alexnet-v0.2.0/binary_alexnet.json
+    binary_alexnet-v0.3.0/binary_alexnet.json
     ```
     ```summary
     literature.BinaryAlexNet

--- a/larq_zoo/literature/binary_alex_net.py
+++ b/larq_zoo/literature/binary_alex_net.py
@@ -75,7 +75,11 @@ class BinaryAlexNetFactory(ModelFactory):
 
         # Classifier
         if self.include_top:
-            out = tf.keras.layers.Reshape((1, 1, -1))(out)
+            try:
+                channels = out.shape[-1] * out.shape[-2] * out.shape[-3]
+            except TypeError:
+                channels = -1
+            out = tf.keras.layers.Reshape((1, 1, channels))(out)
             out = self.dense_block(out, units=4096)
             out = self.dense_block(out, units=4096)
             out = self.dense_block(out, self.num_classes)


### PR DESCRIPTION
This PR updates `BinaryAlexNet` to use 1x1 convolutions in the classification layer which allows correct conversion to LCE.
This brings the official benchmarks inline with the numbers we quote in the LCE paper. This has a big impact since the classification layers are actually very large.

This code has been lying around on my system for a long time now, so I briefly spent a few minutes converting the weights which was just a matter of reshaping the weights of the last four classification layers.