### PR TITLE
Fix CI issue by pinning Keras version to match with TF

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install dependencies
-        run: pip install tensorflow-cpu==2.6.0 -e .[test]
+        run: pip install tensorflow-cpu==2.6.0 keras==2.6.0 -e .[test]
       - name: Test training with pytest
         run: pytest tests/train_test.py -n auto --cov=larq_zoo --cov-report=xml --cov-config=.coveragerc --cov-append
       - name: Upload coverage to Codecov

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Fix TFDS for older TF versions
         run: pip install tensorflow_datasets==3.2.*
         if: matrix.tf-version == '1.15.5' || matrix.tf-version == '2.0.4'
+      - name: Pin Keras for older TF versions
+        run: pip install keras==2.6.0
+        if: matrix.tf-version <= '2.6.0'
       - name: Install dependencies
         run: |
           pip install tensorflow-cpu==${{matrix.tf-version}} || pip install tensorflow==${{matrix.tf-version}}


### PR DESCRIPTION
CI was failing since yesterday because of a mismatching Keras version as suggested on [SO](https://stackoverflow.com/a/69830680/4807429). By explicitly installing `keras==2.6.0` it is resolved. It was caused by keras 2.7 being released yesterday (https://pypi.org/project/keras/#history) and since we don't pin it this caused issues.
