### PR TITLE
Add Support for TensorFlow 2.10

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,22 +11,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tf-version: [1.15.5, 2.0.4, 2.1.4, 2.2.3, 2.3.4, 2.4.4, 2.5.2, 2.6.4, 2.7.2, 2.8.1, 2.9.0]
+        tf-version: [1.15.5, 2.0.4, 2.1.4, 2.2.3, 2.3.4, 2.4.4, 2.5.3, 2.6.5, 2.7.3, 2.8.2, 2.9.1, 2.10.0-rc1]
         python-version: [3.7]
         include:
           - tf-version: 2.4.4
             python-version: 3.6
           - tf-version: 2.4.4
             python-version: 3.8
-          - tf-version: 2.5.2
+          - tf-version: 2.5.3
             python-version: 3.9
-          - tf-version: 2.6.4
+          - tf-version: 2.6.5
             python-version: 3.9
-          - tf-version: 2.7.2
+          - tf-version: 2.7.3
             python-version: 3.9
-          - tf-version: 2.8.1
+          - tf-version: 2.8.2
             python-version: "3.10"
-          - tf-version: 2.9.0
+          - tf-version: 2.9.1
+            python-version: "3.10"
+          - tf-version: 2.10.0-rc1
             python-version: "3.10"
     steps:
       - uses: actions/checkout@v3

--- a/larq_zoo/core/utils.py
+++ b/larq_zoo/core/utils.py
@@ -5,14 +5,15 @@ import sys
 from typing import Optional, Union
 
 import tensorflow as tf
+from packaging import version
 from tensorflow.python.eager.context import num_gpus
 
-if tf.__version__[0] > "1":
+if version.parse(tf.__version__) >= version.parse("2"):
     is_keras_tensor = tf.keras.backend.is_keras_tensor
 else:
     from tensorflow.python.keras.backend import is_keras_tensor
 
-if tf.__version__[:3] > "2.5":
+if version.parse(tf.__version__) >= version.parse("2.6"):
     from keras.applications.imagenet_utils import obtain_input_shape
 else:
     try:
@@ -27,7 +28,7 @@ else:
         )
 
 try:
-    if tf.__version__[:3] > "2.5":
+    if version.parse(tf.__version__) >= version.parse("2.6"):
         from keras.engine.keras_tensor import KerasTensor
     else:
         from tensorflow.python.keras.engine.keras_tensor import KerasTensor

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     license="Apache 2.0",
     install_requires=[
         "numpy>=1.15.0",
+        "packaging>=19",
         "larq>=0.9.2,<0.13.0",
         "zookeeper>=1.0.0,<1.4.0",
         "importlib-metadata ~= 2.0 ; python_version<'3.8'",


### PR DESCRIPTION
This PR fixes the version check to handle TensorFlow 2.10. The checks were previously broken since `2.10` got interpreted as `2.1`.