### PR TITLE
:arrow_up: 2.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 setup(
     name="larq-zoo",
-    version="2.3.0",
+    version="2.3.1",
     author="Plumerai",
     author_email="opensource@plumerai.com",
     description="Reference implementations of popular Binarized Neural Networks",


### PR DESCRIPTION
Bump version number to release #403 which is required for https://github.com/larq/compute-engine/pull/749