### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run Flake8
         run: flake8
       - name: Black code style
-        run: black . --check --target-version py36
+        run: black . --check --target-version py37
       - name: Check import order with isort
         run: isort . --check --diff
       - name: Type check with PyType

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -15,8 +15,6 @@ jobs:
         python-version: [3.7]
         include:
           - tf-version: 2.4.4
-            python-version: 3.6
-          - tf-version: 2.4.4
             python-version: 3.8
           - tf-version: 2.5.3
             python-version: 3.9

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For more information, see [larq.dev/zoo](https://docs.larq.dev/zoo/).
 
 Before installing Larq Zoo, please install:
 
-- [Python](https://python.org) version `3.6`, `3.7`, `3.8`, or `3.9`
+- [Python](https://python.org) version `3.7`, `3.8`, `3.9`, or `3.10`
 - [Tensorflow](https://www.tensorflow.org/install) version `1.15`, `2.0`, `2.1`, `2.2`, `2.3`, `2.4`, `2.5`, `2.6`, 2.7`, or `2.8`
 
 ## Installation

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 def readme():
-    with open("README.md", "r") as f:
+    with open("README.md") as f:
         return f.read()
 
 
@@ -52,10 +52,10 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
Python 3.6 is [EOL since 23 Dec 2021](https://endoflife.date/python). I think it is save to drop support for it at this point.

Closes #415 