### PR TITLE
Add compatibility with Keras export script

### DIFF
--- a/larq_zoo/core/utils.py
+++ b/larq_zoo/core/utils.py
@@ -14,7 +14,10 @@ else:
     from tensorflow.python.keras.backend import is_keras_tensor
 
 if version.parse(tf.__version__) >= version.parse("2.6"):
-    from keras.applications.imagenet_utils import obtain_input_shape
+    try:
+        from keras.applications.imagenet_utils import obtain_input_shape
+    except ImportError:
+        from keras.src.applications.imagenet_utils import obtain_input_shape
 else:
     try:
         # type: ignore

--- a/larq_zoo/core/utils.py
+++ b/larq_zoo/core/utils.py
@@ -17,6 +17,7 @@ if version.parse(tf.__version__) >= version.parse("2.6"):
     try:
         from keras.applications.imagenet_utils import obtain_input_shape
     except ImportError:
+        # type: ignore
         from keras.src.applications.imagenet_utils import obtain_input_shape
 else:
     try:


### PR DESCRIPTION
With [this script](https://github.com/keras-team/keras/blob/master/pip_build.py) Keras hides internal functions. Since `obtain_input_shape` is an internal function used by the Larq zoo, that no longer works with Keras 2.13 on my system. This is a work-around. Of course a proper solution would be to only use public functions.

Since the Keras export script is currently only targeting [x86-64 Linux](https://github.com/keras-team/keras/blob/master/pip_build.py#L28), I solved this by using a try-except rather than an `if version.parse()` statement.