### PR TITLE
Replace black, flake8, and isort with ruff for linting and formatting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,11 +20,9 @@ jobs:
         run: |
           pip install tensorflow-cpu==2.10.1
           pip install -e .[test]
-      - name: Run Flake8
-        run: flake8
-      - name: Black code style
-        run: black . --check --target-version py310
-      - name: Check import order with isort
-        run: isort . --check --diff
+      - name: Ruff format check
+        run: ruff format . --check
+      - name: Ruff lint check
+        run: ruff check .
       - name: Type check with PyType
         run: pytype --jobs auto

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Ruff lint check
         run: ruff check .
       - name: Type check with PyType
-        run: pytype --jobs auto
+        run: pytype --config setup.cfg --jobs auto

--- a/larq_zoo/core/utils.py
+++ b/larq_zoo/core/utils.py
@@ -82,9 +82,9 @@ class ModelCheckpoint(tf.keras.callbacks.ModelCheckpoint):
 def get_distribution_scope(batch_size):
     if num_gpus() > 1:
         strategy = tf.distribute.MirroredStrategy()
-        assert (
-            batch_size % strategy.num_replicas_in_sync == 0
-        ), f"Batch size {batch_size} cannot be divided onto {num_gpus()} GPUs"
+        assert batch_size % strategy.num_replicas_in_sync == 0, (
+            f"Batch size {batch_size} cannot be divided onto {num_gpus()} GPUs"
+        )
         distribution_scope = strategy.scope
     else:
         if sys.version_info >= (3, 7):
@@ -105,8 +105,7 @@ def validate_input(input_shape, weights, include_top, classes):
 
     if weights == "imagenet" and include_top and classes != 1000:
         raise ValueError(
-            "If using `weights` as `imagenet` with `include_top` as true, "
-            "`classes` should be 1000"
+            "If using `weights` as `imagenet` with `include_top` as true, `classes` should be 1000"
         )
 
     # Determine proper input shape

--- a/larq_zoo/literature/resnet_e.py
+++ b/larq_zoo/literature/resnet_e.py
@@ -38,8 +38,10 @@ class BinaryResNetE18Factory(ModelFactory):
         }
         try:
             return spec[self.num_layers]
-        except Exception:
-            raise ValueError(f"Only specs for layers {list(self.spec.keys())} defined.")
+        except Exception as e:
+            raise ValueError(
+                f"Only specs for layers {list(self.spec.keys())} defined."
+            ) from e
 
     def residual_block(self, x: tf.Tensor, filters: int, strides: int = 1) -> tf.Tensor:
         downsample = x.get_shape().as_list()[-1] != filters

--- a/larq_zoo/sota/quicknet.py
+++ b/larq_zoo/sota/quicknet.py
@@ -154,10 +154,10 @@ class QuickNetFactory(ModelFactory):
     def build(self) -> tf.keras.models.Model:
         x = self.stem_module(self.section_filters[0], self.image_input)
 
-        for block, (layers, filters) in enumerate(
+        for _block, (layers, filters) in enumerate(
             zip(self.section_blocks, self.section_filters)
         ):
-            for layer in range(layers):
+            for _layer in range(layers):
                 if filters != x.shape[-1]:
                     x = self.transition_block(x, filters, strides=2)
                 x = self.residual_block(x)

--- a/larq_zoo/training/knowledge_distillation/knowledge_distillation.py
+++ b/larq_zoo/training/knowledge_distillation/knowledge_distillation.py
@@ -35,7 +35,7 @@ class AttentionMatchingLossLayer(tf.keras.layers.Layer):
             [
                 x,
                 [teacher.block1_output, teacher.block2_output],
-                [student.block1_output, student.block2_output]
+                [student.block1_output, student.block2_output],
             ]
         )
         ```
@@ -273,9 +273,9 @@ def get_unique_layer_with_partial_name(
         in its `layer.name`
     """
     results = [layer for layer in model.layers if partial_name in layer.name]
-    assert (
-        len(results) == 1
-    ), f"Expected to find one layer matching {partial_name} in {model.name}, found {len(results)}"
+    assert len(results) == 1, (
+        f"Expected to find one layer matching {partial_name} in {model.name}, found {len(results)}"
+    )
     return results[0]
 
 
@@ -393,7 +393,9 @@ class TeacherStudentModelFactory(ModelFactory):
         else:
             assert (
                 self.output_matching_weight > 0 or self.attention_matching_weight > 0
-            ), "Teacher model loaded but all teacher-student knowledge distillation losses are 0"
+            ), (
+                "Teacher model loaded but all teacher-student knowledge distillation losses are 0"
+            )
 
         assert (
             len(self.teacher_model.inputs) == 1 and len(self.student_model.inputs) == 1

--- a/larq_zoo/training/knowledge_distillation/multi_stage_training.py
+++ b/larq_zoo/training/knowledge_distillation/multi_stage_training.py
@@ -107,7 +107,7 @@ class LarqZooModelTrainingPhase(TrainingPhase):
 
     @Field
     def loss(self):
-        return getattr(self.__base_getattribute__("model"), "classification_loss")
+        return self.__base_getattribute__("model").classification_loss
 
     metrics = Field(lambda: ["accuracy", "sparse_top_k_categorical_accuracy"])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.format]
+docstring-code-format = true
+
+[tool.ruff.lint]
+select = ["I", "E", "W", "F", "B"]
+ignore = ["E501"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,24 +1,3 @@
-[flake8]
-
-# Black compatibility.
-ignore = E203,E501,W503
-exclude = build,dist,env,.pytype,.venv,venv
-
-
-[isort]
-
-profile = black
-# Don't misclassify larq as a first-party import.
-known_third_party = larq
-skip =
-    build
-    dist
-    venv
-    .venv
-    .git
-    .pytype
-
-
 [pytype]
 
 inputs = .

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,9 @@ setup(
         "tensorflow": ["tensorflow>=2.8.4"],
         "tensorflow_gpu": ["tensorflow-gpu>=2.8.4"],
         "test": [
-            "black==26.3.1",
             "dill==0.4.1",
-            "flake8==7.3.0",
-            "isort==8.0.1",
             "pytype==2024.10.11",
+            "ruff==0.11.4",
             "pytest==9.0.2",
             "pytest-cov==7.1.0",
             "pytest-mock==3.15.1",


### PR DESCRIPTION
Removes black, flake8, and isort from test dependencies and CI workflow, replacing them with ruff for both formatting and lint checking. Adds a pyproject.toml with ruff configuration. Fixes minor lint issues caught by ruff (B904, B007) and reformats code with ruff format.