### PR TITLE
Bump CI dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "packaging>=19",
         "larq>=0.9.2,<0.13.2",
         "zookeeper>=1.0.0",
-        "typeguard<3.0.0",
+        "typeguard<4.0.0",
         "protobuf<3.21",
     ],
     extras_require={
@@ -31,8 +31,8 @@ setup(
         "test": [
             "dill==0.4.1",
             "pytype==2024.10.11",
-            "ruff==0.15.12",
-            "pytest==9.0.2",
+            "ruff==0.15.13",
+            "pytest==9.0.3",
             "pytest-cov==7.1.0",
             "pytest-mock==3.15.1",
             "pytest-xdist==3.8.0",


### PR DESCRIPTION
  Bump CI dependencies to latest patch versions.

  - `typeguard`: `<3.0.0` → `<4.0.0` (transitively still constrained to <3 by zookeeper, but relaxes the local upper bound)
  - `ruff`: `0.15.12` → `0.15.13`
  - `pytest`: `9.0.2` → `9.0.3`

  Closes #581.

  Note: Not bumping `larq` to `<0.13.4` (PR #582). larq 0.13.3 breaks the XNORNet tests — `xnor_weight_scale` fails to deserialize with `TypeError: xnor_weight_scale() missing 1 required positional argument: 'x'`. Needs separate
  investigation.
