### PR TITLE
Fix larq 0.13.3 compat

### DIFF
--- a/larq_zoo/literature/xnornet.py
+++ b/larq_zoo/literature/xnornet.py
@@ -25,7 +25,7 @@ class XNORNetFactory(ModelFactory):
     """Implementation of [XNOR-Net](https://arxiv.org/abs/1603.05279)"""
 
     input_quantizer = "ste_sign"
-    kernel_quantizer = "xnor_weight_scale"
+    kernel_quantizer = staticmethod(xnor_weight_scale)
     kernel_constraint = "weight_clip"
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,8 @@ setup(
     install_requires=[
         "numpy>=1.15.0",
         "packaging>=19",
-        "larq>=0.9.2,<0.13.2",
+        "larq>=0.9.2",
         "zookeeper>=1.0.0",
-        "typeguard<4.0.0",
         "protobuf<3.21",
     ],
     extras_require={


### PR DESCRIPTION
larq 0.13.2 changed `quantizers.get(str)` to wrap the string in`{"class_name": str, "config": {}}` and run it through the new Keras deserialisation path. That path tries to *instantiate* the registered object as a class — fine for `Quantizer` subclasses, but for the function-typed quantizer `xnor_weight_scale` it ends up calling `xnor_weight_scale()` with no arguments and raises `TypeError: missing 1 required positional argument: 'x'`.

Bypass the broken string lookup by referencing the function directly in `XNORNetFactory.kernel_quantizer`. The `staticmethod` wrapper is needed because a plain function set as a class attribute would be bound as a method when accessed via the instance, prepending `self` to the argument list and breaking the quantizer call.

Drop the now-unnecessary `larq<0.13.2` upper bound (and the redundant `typeguard` constraint, which is supplied transitively via zookeeper).