### PR TITLE
Bump version to 2.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 setup(
     name="larq-zoo",
-    version="2.3.3",
+    version="2.4.0",
     author="Plumerai",
     author_email="opensource@plumerai.com",
     description="Reference implementations of popular Binarized Neural Networks",


### PR DESCRIPTION
Release the modernization work (ruff, Python >=3.10) plus the XNORNet/larq 0.13.2+ fix. Minor bump since dropping Python 3.9 is breaking.